### PR TITLE
Rename VM to VirtualMachine

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 >
 > Note: This is a heavy work in progress. We do our best to keep it in sync with released features. If you encounter any problem, please file an [issue](https://github.com/kubevirt/kubevirt/issues).
 
-KubeVirt is  Kubernetes add-on to run virtual machines \(VMs\) on a Kubernetes cluster. This document is intended for users, and will guide through installation and various features.
+KubeVirt is  Kubernetes add-on to run virtual machines \(VirtualMachines\) on a Kubernetes cluster. This document is intended for users, and will guide through installation and various features.
 
 
 **Read it at:**

--- a/access.md
+++ b/access.md
@@ -5,7 +5,7 @@ Once a virtual machine got started you are able to connect to the consoles it ex
 * Serial Console
 * Graphical Console
 
-> Note: You need to have `virtctl` [installed](installation.md) to gain access to the VM.
+> Note: You need to have `virtctl` [installed](installation.md) to gain access to the VirtualMachine.
 
 ### Accessing the serial console
 

--- a/installation.md
+++ b/installation.md
@@ -49,14 +49,14 @@ See the [developer getting started guide](https://github.com/kubevirt/kubevirt/b
 
 ### Client side `virtctl` deployment
 
-Basic VM operations can be peformed with the stock `kubectl` utility. However, the `virtctl` binary utility is required to use advanced features such as:
+Basic VirtualMachine operations can be peformed with the stock `kubectl` utility. However, the `virtctl` binary utility is required to use advanced features such as:
 
 * Serial and graphical console access
 
 Or to have convenience commands for:
 
-* Starting and stopping VMs
-* Live migrating VMs
+* Starting and stopping VirtualMachines
+* Live migrating VirtualMachines
 
 The most recent version of the tool can be retrieved from the [official release page](https://github.com/kubevirt/kubevirt/releases).
 

--- a/live-migration.md
+++ b/live-migration.md
@@ -1,12 +1,12 @@
 ## Live migrating a virtual machine
 
-Live migrating a virtual machine allows you to move a VM from one host to another, without shutting it down.
+Live migrating a virtual machine allows you to move a VirtualMachine from one host to another, without shutting it down.
 
 Live migration is supported if your cluster has got more than two nodes.
 
 ### Starting a live migration
 
-A live migration is triggered by creating a `Migration` object. You need to set a `selector` to specify the VM to be migrated.
+A live migration is triggered by creating a `Migration` object. You need to set a `selector` to specify the VirtualMachine to be migrated.
 
 The example below shows as usual migration object:
 
@@ -46,18 +46,18 @@ Aborting a live migration is not yet supported.
 
 ## Fine tuning
 
-The previous paragraphs explained the basic flow for live migrating a VM.
+The previous paragraphs explained the basic flow for live migrating a VirtualMachine.
 In this section we are looking at additional tuning parameters which influence
 the migration in certain areas.
 
-### Influencing where a VM migrates
+### Influencing where a VirtualMachine migrates
 
 > **Note:** This section is about using the `nodeSelector` to select migration
 > destinations. Node- and Pod-Affinity as present in recent versions of Kubernetes
-> is not yet supported for VMs.
+> is not yet supported for VirtualMachines.
 
-The VM will always be scheduled to another node than where it is running on, or
-the migration fails. To further influence where VM migrates, a `nodeSelector`
+The VirtualMachine will always be scheduled to another node than where it is running on, or
+the migration fails. To further influence where VirtualMachine migrates, a `nodeSelector`
 section can be added to a Migration:
 
 ```yaml
@@ -72,12 +72,12 @@ spec:
     ram: fast
 ```
 
-In this example, the VM will only be migrated to nodes which have the label
+In this example, the VirtualMachine will only be migrated to nodes which have the label
 `ram: fast` assigned.
 
-#### Migrate a VM to a specific Node
+#### Migrate a VirtualMachine to a specific Node
 
-The scheduler can be forced to migrate a VM to a specific node, if enough
+The scheduler can be forced to migrate a VirtualMachine to a specific node, if enough
 resources are available on the target node. For selecting the target node, the
 special `kubernetes.io/hostname` label can be used. It is applied by Kubernetes
 to every node and is guaranteed to be unique.
@@ -96,20 +96,20 @@ spec:
     kubernetes.io/hostname: slave1
 ```
 
-In this case the VM will be migrated to the node `slave1`, or the migration
+In this case the VirtualMachine will be migrated to the node `slave1`, or the migration
 fails if that is not possible.
 
-#### Merging VM and Migration nodeSelector requirements
+#### Merging VirtualMachine and Migration nodeSelector requirements
 
-A VM can already contain a `nodeSelector` section itself. A Migration will
+A VirtualMachine can already contain a `nodeSelector` section itself. A Migration will
 always respect them. Both sections will be merged **only** for the current
 migration.
 
-Given a VM
+Given a VirtualMachine
 
 ```yaml
 apiVersion: kubevirt.io/v1alpha1
-kind: VM
+kind: VirtualMachine
 metadata:
   name: testvm
 spec:
@@ -138,12 +138,12 @@ spec:
 ```
 
 The migration controller will combine the two node selectors, and look for
-nodes which match both, `ram: fast` and `storage: ssd`. The VM itself will only
+nodes which match both, `ram: fast` and `storage: ssd`. The VirtualMachine itself will only
 contain the original `nodeSelector` section afterwards. Later migrations are
 therefore not influenced by the additional migration labels.
 
 #### Resolving nodeSelector conflicts
 
-Since the `nodeSelector` section is a hard requirement of  the VM, they can't
+Since the `nodeSelector` section is a hard requirement of  the VirtualMachine, they can't
 be overwritten. In case the `nodeSelector` section of a Migration conflicts
-with the `nodeSelector` section of a VM, the migration will fail.
+with the `nodeSelector` section of a VirtualMachine, the migration will fail.

--- a/vm-creation.md
+++ b/vm-creation.md
@@ -6,17 +6,17 @@ With the installation of KubeVirt, new types are added to the Kubernetes API to 
 
 You can interact with the new resources \(via `kubectl`\) as you would with any other API resource.
 
-### VM API
+### VirtualMachine API
 
-> Note: Currently there is no offline documentation of the VM API.
+> Note: Currently there is no offline documentation of the VirtualMachine API.
 
-A VM API is also called a VM object, because the object is used to define a virtual machine.
+A VirtualMachine API is also called a VirtualMachine object, because the object is used to define a virtual machine.
 
-Here is an example of a VM object:
+Here is an example of a VirtualMachine object:
 
 ```yaml
 apiVersion: kubevirt.io/v1alpha1
-kind: VM
+kind: VirtualMachine
 metadata:
   name: testvm
 spec:

--- a/vm-life-cycle.md
+++ b/vm-life-cycle.md
@@ -1,8 +1,8 @@
 ## Basic Life-cycle
 
-Every `VM` represents a single virtual machine _instance_.  
-In general, the management of VMs is kept similar to how `Pods` are managed: Every Vm that is defined in the cluster is expected to be running, just like pods.  
-Deleting a VM is equivalent to shutting it down, this is also equivalent to how pods behave.
+Every `VirtualMachine` represents a single virtual machine _instance_.  
+In general, the management of VirtualMachines is kept similar to how `Pods` are managed: Every Vm that is defined in the cluster is expected to be running, just like pods.  
+Deleting a VirtualMachine is equivalent to shutting it down, this is also equivalent to how pods behave.
 
 FIXME needs to be reworked.
 
@@ -12,7 +12,7 @@ FIXME needs to be reworked.
 
 ### Launching a virtual machine
 
-In order to start a VM, you just need to create a `VM` object using `kubectl`:
+In order to start a VirtualMachine, you just need to create a `VirtualMachine` object using `kubectl`:
 
 ```bash
 $ kubectl create -f vm.yaml
@@ -20,7 +20,7 @@ $ kubectl create -f vm.yaml
 
 ### Listing virtual machines
 
-VMs can be listed by querying for VM objects:
+VirtualMachines can be listed by querying for VirtualMachine objects:
 
 ```bash
 $ kubectl get vms
@@ -28,7 +28,7 @@ $ kubectl get vms
 
 ### Retrieving a virtual machine definition
 
-A single VM definition can be retrieved by getting the specific VM object:
+A single VirtualMachine definition can be retrieved by getting the specific VirtualMachine object:
 
 ```bash
 $ kubectl get vms testvm
@@ -36,7 +36,7 @@ $ kubectl get vms testvm
 
 ### Stopping a virtual machine
 
-To stop the VM, you just need to delete the corresponding `VM` object using `kubectl`.
+To stop the VirtualMachine, you just need to delete the corresponding `VirtualMachine` object using `kubectl`.
 
 ```bash
 $ kubectl delete -f vm.yaml
@@ -44,7 +44,7 @@ $ kubectl delete -f vm.yaml
 $ kubectl delete vms testvm
 ```
 
-> Note: Stopping a VM implies that it will be deleted from the cluster. You will not be able to start this VM object again.
+> Note: Stopping a VirtualMachine implies that it will be deleted from the cluster. You will not be able to start this VirtualMachine object again.
 
 
 


### PR DESCRIPTION
With the switch from TPRs to CRDs, it is now possible to name our
VirtualMachine object properly while still keeping the nice vm and vms
shortcuts for kubectl.

Stay in sync with https://github.com/kubevirt/kubevirt/pull/452

Signed-off-by: Roman Mohr <rmohr@redhat.com>