### PR TITLE
Add anchors to user-guide pages

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,0 +1,3 @@
+{
+    "plugins" : [ "anchors" ]
+}


### PR DESCRIPTION
On longer documentation pages it is hard to point people to the right section. Let's add the anchors plugin, so that we can share links to headings inside a page.

`gitbook install` will install the plugin. On gitbook.com this happens implicitly.

Signed-off-by: Roman Mohr <rmohr@redhat.com>