### PR TITLE
VNC/Console RBAC Role documentation

### DIFF
--- a/access.md
+++ b/access.md
@@ -9,6 +9,52 @@ exposes. Usually there are two types of consoles:
 > Note: You need to have `virtctl` [installed](installation.md) to gain access
 > to the VirtualMachine.
 
+
+### RBAC Permissions for Console/VNC Access
+
+Admins with full cluster privileges already have access to all virtual machines.
+
+Users and Service Accounts can be granted access to virtual machine console/VNC
+access via RBAC roles.
+
+Below is an example of a ClusterRole which grants access to all virtual machine
+consoles and VNC.
+
+```
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: allow-vnc-console-access
+rules:
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/console
+      - virtualmachines/vnc
+    verbs:
+      - get
+
+```
+
+The ClusterRole above provides access to virtual machines across all namespaces.
+In order to reduce the scope to a single namespace, use a Role object instead.
+
+```
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: allow-vnc-console-access
+  namespace: default
+rules:
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/console
+      - virtualmachines/vnc
+    verbs:
+      - get
+```
+
 ### Accessing the serial console
 
 The serial console of a virtual machine can be accessed by using the `console`


### PR DESCRIPTION
This reflects the changes to RBAC permissions for VM Console/VNC access that are landing as a part of this PR, https://github.com/kubevirt/kubevirt/pull/770