### PR TITLE
Update service integration documentation

### DIFF
--- a/workloads/controllers/README.md
+++ b/workloads/controllers/README.md
@@ -1,4 +1,7 @@
 # Controllers
 
-Controllers provide the logic to manage virtual machine instances in a way that addresses specific use-cases.
+Controllers provide the logic to manage virtual machine instances in a way that
+addresses specific use-cases:
 
+ * [VirtualMachineReplicaSet](virtual-machine-replica-set.md): Replicating stateless Virtual Machines.
+ * [OfflineVirtualMachine](offline-virtual-machine.md): Stateful Virtual Machine, similar to a StatefulSet with replicas set to 1.

--- a/workloads/virtual-machines/expose-service.md
+++ b/workloads/virtual-machines/expose-service.md
@@ -157,3 +157,17 @@ lbsvc     LoadBalancer   172.30.27.5      172.29.10.235,172.29.10.235   27017:31
 
 Use `vinagre` client to connect your VirtualMachine by using the public IP and
 port.
+
+## Directly exposing the Pod behind the VirtualMachine
+
+It is also possible to use `kubectl expose` to expose the pod of the
+VirtualMachine directly:
+
+```bash
+$ kubectl get pod -l "special=key"
+NAME                                READY     STATUS    RESTARTS   AGE
+virt-launcher-windows2012r2-x9x2f   1/1       Running   0          9m
+$ kubectl expose pod virt-launcher-windows2012r2-x9x2f --port=27017 --target-port=3389 --name=lbsvc --type=LoadBalancer
+```
+
+We will soon provide a similar command for `virtctl`.

--- a/workloads/virtual-machines/expose-service.md
+++ b/workloads/virtual-machines/expose-service.md
@@ -2,20 +2,49 @@
 
 ## Expose VirtualMachine as a service
 
-Once the VirtualMachine is started, in order to connect to a VirtualMachine, you can create a `Service` object for a VirtualMachine.
-Currently, three types of service are supported: `ClusterIP`, `NodePort` and `LoadBalancer`. The default type is `ClusterIP`.
+Once the VirtualMachine is started, in order to connect to a VirtualMachine,
+you can create a `Service` object for a VirtualMachine.  Currently, three types
+of service are supported: `ClusterIP`, `NodePort` and `LoadBalancer`. The
+default type is `ClusterIP`.
+
+> **Note**: Labels on a VirtualMachine are passed through to the pod, so simply
+> add your labels for service creation to the vm. From there on it works like
+> exposing any other k8s resource, by referencing these labels in a service.
 
 ## Expose VirtualMachine as a ClusterIP service
 
-Expose the SSH port (22) of a VirtualMachine running on KubeVirt by creating a `ClusterIP service`. Here is an example of a ClusterIP service:
+Give a VirtualMachine wit the label `special: key`:
+
+```yaml
+apiVersion: kubevirt.io/v1alpha1
+kind: VirtualMachine
+metadata:
+  name: vm-ephemeral
+  labels:
+    special: key
+spec:
+  domain:
+    devices:
+      disks:
+      - disk:
+          bus: virtio
+        name: registrydisk
+        volumeName: registryvolume
+    resources:
+      requests:
+        memory: 64M
+  volumes:
+  - name: registryvolume
+    registryDisk:
+      image: kubevirt/cirros-registry-disk-demo:latest
+```
+
+we can expose its SSH port (22) by creating a `ClusterIP service`:
 
 ```yaml
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    kubevirt.io: virt-launcher
-    kubevirt.io/domain: testvm-ephemeral
   name: vmservice
 spec:
   ports:
@@ -23,20 +52,14 @@ spec:
     protocol: TCP
     targetPort: 22
   selector:
-    kubevirt.io: virt-launcher
-    kubevirt.io/domain: testvm-ephemeral
+    special: key
   type: ClusterIP
 ```
 
 You just need to create this `ClusterIP service` by using `kubectl`:
 
 ```bash
-$ kubectl -f svc.yaml
-# OR
-$ kubectl get pod
-NAME                                   READY     STATUS    RESTARTS   AGE
-virt-launcher-testvm-ephemeral-9bqv4   2/2       Running   0          10m
-$ kubectl expose pod virt-launcher-testvm-ephemeral-9bqv4 --port=27017 --target-port=22 --name=vmservice
+$ kubectl create -f svc.yaml
 ```
 
 Query the service object:
@@ -55,15 +78,13 @@ $ ssh cirros@172.30.3.149 -p 27017
 
 ## Expose VirtualMachine as a NodePort service
 
-Expose the SSH port (22) of a VirtualMachine running on KubeVirt by creating a `NodePort service`. Here is an example of a NodePort service:
+Expose the SSH port (22) of a VirtualMachine running on KubeVirt by creating a
+`NodePort service`:
 
 ```yaml
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    kubevirt.io: virt-launcher
-    kubevirt.io/domain: testvm-ephemeral
   name: testnodeport
 spec:
   externalTrafficPolicy: Cluster
@@ -74,8 +95,7 @@ spec:
     protocol: TCP
     targetPort: 22
   selector:
-    kubevirt.io: virt-launcher
-    kubevirt.io/domain: testvm-ephemeral
+    special: key
   type: NodePort
 ```
 
@@ -83,11 +103,6 @@ You just need to create this `NodePort service` by using `kubectl`:
 
 ```bash
 $ kubectl -f nodeport.yaml
-# OR
-$ kubectl get pod
-NAME                                   READY     STATUS    RESTARTS   AGE
-virt-launcher-testvm-ephemeral-9bqv4   2/2       Running   0          10m
-$ kubectl expose pod virt-launcher-testvm-ephemeral-mxjh8 --port=27017 --target-port=22 --type=NodePort --name=nodeportsvc
 ```
 
 The service can be listed by querying for the service objects:
@@ -98,7 +113,8 @@ NAME           TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)           AGE
 nodeportsvc    NodePort   172.30.232.73   <none>        27017:30000/TCP   5m
 ```
 
-Connect to the VirtualMachine by using a node IP and node port outside the clusternetwork:
+Connect to the VirtualMachine by using a node IP and node port outside the
+clusternetwork:
 
 ```bash
 $ ssh cirros@$NODE_IP -p 30000
@@ -106,15 +122,13 @@ $ ssh cirros@$NODE_IP -p 30000
 
 ## Expose VirtualMachine as a LoadBalancer service
 
-Expose the RDP port (3389) of a VirtualMachine running on KubeVirt by creating `LoadBalancer service`. Here is an example of a LoadBalancer service:
+Expose the RDP port (3389) of a VirtualMachine running on KubeVirt by creating
+`LoadBalancer service`. Here is an example of a LoadBalancer service:
 
 ```yaml
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    kubevirt.io: virt-launcher
-    kubevirt.io/domain: windows2012r2
   name: lbsvc
 spec:
   externalTrafficPolicy: Cluster
@@ -123,8 +137,7 @@ spec:
     protocol: TCP
     targetPort: 3389
   selector:
-    kubevirt.io: virt-launcher
-    kubevirt.io/domain: windows2012r2
+    speical: key
   type: LoadBalancer
 ```
 
@@ -132,11 +145,6 @@ You could create this `LoadBalancer` service by using `kubectl`:
 
 ```bash
 $ kubectl -f lbsvc.yaml
-# OR
-$ kubectl get pod
-NAME                                READY     STATUS    RESTARTS   AGE
-virt-launcher-windows2012r2-x9x2f   1/1       Running   0          9m
-$ kubectl expose pod virt-launcher-windows2012r2-x9x2f --port=27017 --target-port=3389 --name=lbsvc --type=LoadBalancer
 ```
 
 The service can be listed by querying for the service objects:
@@ -147,4 +155,5 @@ NAME      TYPE           CLUSTER-IP       EXTERNAL-IP                   PORT(S) 
 lbsvc     LoadBalancer   172.30.27.5      172.29.10.235,172.29.10.235   27017:31829/TCP   5s
 ```
 
-Use `vinagre` client to connect your VirtualMachine by using the public IP and port.
+Use `vinagre` client to connect your VirtualMachine by using the public IP and
+port.


### PR DESCRIPTION
Focus more on how to expose the VM, than on how to expose the underlying pod. Tries to address confusions on how well we can integrate with core-services, although we are using CRDs and not an alternative container runtime for virtualization workloads.