### PR TITLE
Fix create example

### DIFF
--- a/workloads/virtual-machines/creation.md
+++ b/workloads/virtual-machines/creation.md
@@ -8,7 +8,7 @@ You can interact with the new resources \(via `kubectl`\) as you would with any 
 
 ## VirtualMachine API
 
-> Note: Currently there is no offline documentation of the VirtualMachine API.
+> Note: A full API reference is available at (https://kubevirt.io/api-reference/)[https://kubevirt.io/api-reference/].
 
 A VirtualMachine API is also called a VirtualMachine object, because the object is used to define a virtual machine.
 
@@ -18,24 +18,49 @@ Here is an example of a VirtualMachine object:
 apiVersion: kubevirt.io/v1alpha1
 kind: VirtualMachine
 metadata:
-  name: testvm
+  name: testvm-nocloud
 spec:
-  terminationGracePeriodSeconds: 0
+  terminationGracePeriodSeconds: 30
   domain:
     resources:
       requests:
-        memory: 64M
+        memory: 1024M
     devices:
       disks:
-      - name: mydisk
-        volumeName: myvolume
+      - name: registrydisk
+        volumeName: registryvolume
         disk:
-          dev: vda
+          bus: virtio
+      - name: emptydisk
+        volumeName: emptydiskvolume
+        disk:
+          bus: virtio
+      - disk:
+          bus: virtio
+        name: cloudinitdisk
+        volumeName: cloudinitvolume
   volumes:
-    - name: myvolume
-      iscsi:
-        iqn: iqn.2017-01.io.kubevirt:sn.42
-        lun: 2
-        targetPortal: iscsi-demo-target.kube-system.svc.cluster.local
+  - name: registryvolume
+    registryDisk:
+      image: kubevirt/fedora-cloud-registry-disk-demo:latest
+  - name: emptydiskvolume
+    emptyDisk:
+      capacity: "2Gi"
+  - name: cloudinitvolume
+    cloudInitNoCloud:
+      userData: |-
+        #cloud-config
+        password: fedora
+        chpasswd: { expire: False }
 ```
 
+This example uses a fedora cloud image in combination with cloud-init and an
+ephemeral empty disk with a capacity of `2Gi`. For the sake of simplicity, the
+volume sources in this example are ephemeral and don't require a provisioner in
+your cluster.
+
+# What's next
+
+ * More information about persistent and ephemeral volumes: [Disks and Volumes](workloads/virtual-machines/disks-and-volumes.md)
+ * How to access a VirtualMachine via `console` or `vnc`: [Graphical and Serial Console Access](workloads/virtual-machines/graphical-and-console-access.md)
+ * How to customize VirtualMachines with `cloud-init`: [Startup Scripts](workloads/virtual-machines/startup-scripts.md)


### PR DESCRIPTION
Add a  more recent example to the creation page. Use only ephemeral storage to avoid the need of a cluster provisioner and finally add some links to follow-up topics.

Fixes #64.