### PR TITLE
Document the new `model` interface attribute

### DIFF
--- a/workloads/virtual-machines/interfaces-and-networks.md
+++ b/workloads/virtual-machines/interfaces-and-networks.md
@@ -60,7 +60,13 @@ This backend type is used if an interface should be connected to the regular pod
 
 In some cases the underlying network plugin (flannel, weave, OpenShift SDN) acts as an Ethernet bridge or switch, in those cases the `pod` backend can also be used to provide an IP level connectivity to an interface (see backend `bridge.delegateIP`).
 
-## Available connections methods
+## Available interface attributes
+
+|Name|Possible values|Default|Description|
+|--|--|--|--|
+|model|e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio|virtio|Interface model type exposed to guest (tip: use e1000 if your image doesn't support virtio)|
+
+### Available connection methods
 
 | Connection method | Description |
 |--|--|


### PR DESCRIPTION
With https://github.com/kubevirt/kubevirt/pull/1167 merged, kubevirt will
support model attribute for interfaces (before the PR, it was supported via
annotations but we never captured that in documentation, so no accommodation
needed).