### PR TITLE
Document annotations and labels of user interest

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -27,4 +27,5 @@
     * [Virtual Machine Replica Set](workloads/controllers/virtual-machine-replica-set.md)
   * [Templates](workloads/templates/README.md)
     * [Virtual Machine Creation](workloads/templates/vm-creation.md)
+  * [Annotations and Labels](misc/annotations_and_labels.md)
 * [Additional resources](additional-resources.md)

--- a/misc/annotations_and_labels.md
+++ b/misc/annotations_and_labels.md
@@ -1,0 +1,40 @@
+# KubeVirt specific annotations and labels
+
+KubeVirt builds on and exposes a number of labels and annotations that either
+are used for internal implementation needs or expose useful information to API
+users. This page documents the labels and annotations that may be useful for
+regular API consumers. This page intentionally does *not* list labels and
+annotations that are merely part of internal implementation.
+
+**Note:** Annotations and labels that are not specific to KubeVirt are also documented
+[here](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/).
+
+## kubevirt.io
+
+Example: kubevirt.io=virt-launcher
+
+Used on: Pod
+
+This label marks resources that belong to KubeVirt. An optional value may
+indicate which specific KubeVirt component a resource belongs to. This label
+may be used to list all resources that belong to KubeVirt, for example, to
+uninstall it from a cluster.
+
+## kubevirt.io/schedulable
+
+Example: kubevirt.io/schedulable=true
+
+Used on: Node
+
+This label declares whether a particular node is available for scheduling
+virtual machine instances on it.
+
+## kubevirt.io/heartbeat
+
+Example: kubevirt.io/heartbeat=2018-07-03T20:07:25Z
+
+Used on: Node
+
+This annotation is regularly updated by virt-handler to help determine if a
+particular node is alive and hence should be available for new virtual machine
+instance scheduling.


### PR DESCRIPTION
Things to focus when reviewing:

- whether the index.html attachment makes sense (I couldn't find a better place to attach the info; and I didn't feel like creating more levels of embedding);
- an argument can be made that this information should be as close to API reference docs as possible (perhaps part of them).

Related to kubevirt/kubevirt#1080