### PR TITLE
Escape colons in MAC addresses

### DIFF
--- a/workloads/virtual-machines/interfaces-and-networks.md
+++ b/workloads/virtual-machines/interfaces-and-networks.md
@@ -71,7 +71,7 @@ properties "seen" inside guest instances, as listed below:
 | Name | Format | Default value | Description |
 |--|--|--|--|
 | `model` | One of: `e1000`, `e1000e`, `ne2k_pci`, `pcnet`, `rtl8139`, `virtio` | `virtio` | NIC type |
-| macAddress | ff:ff:ff:ff:ff:ff or FF-FF-FF-FF-FF-FF | | MAC address as seen inside the guest system, for example: de:ad:00:00:be:af |
+| macAddress | ff\:ff\:ff\:ff\:ff\:ff or FF-FF-FF-FF-FF-FF | | MAC address as seen inside the guest system, for example: de\:ad\:00\:00\:be\:af |
 
 ```yaml
 kind: VM


### PR DESCRIPTION
Markdown format has special meaning for :term:s and trashes MAC
addresses in HTML output unless we escape.