### PR TITLE
Fixed MAC address format in regular text (2nd attempt)

### DIFF
--- a/workloads/virtual-machines/interfaces-and-networks.md
+++ b/workloads/virtual-machines/interfaces-and-networks.md
@@ -71,7 +71,7 @@ properties "seen" inside guest instances, as listed below:
 | Name | Format | Default value | Description |
 |--|--|--|--|
 | `model` | One of: `e1000`, `e1000e`, `ne2k_pci`, `pcnet`, `rtl8139`, `virtio` | `virtio` | NIC type |
-| macAddress | ff\:ff\:ff\:ff\:ff\:ff or FF-FF-FF-FF-FF-FF | | MAC address as seen inside the guest system, for example: de\:ad\:00\:00\:be\:af |
+| macAddress | `ff:ff:ff:ff:ff:ff` or `FF-FF-FF-FF-FF-FF` | | MAC address as seen inside the guest system, for example: `de:ad:00:00:be:af` |
 | ports ||empty| List of ports to be forwarded to the virtual machine. |
 
 ```yaml


### PR DESCRIPTION
The previous attempt [1] to fix the MAC address format in the table
resulted in spurious backslashes in the result output.

This is the second attempt to make the MAC addresses look as they should
in the output. Now instead of escapes, we use ``-strings.

This new change is now validated with the actual web server running. It
works as expected.

[1] https://github.com/kubevirt/user-guide/pull/103