### PR TITLE
Fix cpu-model documentation

### DIFF
--- a/workloads/virtual-machines/virtualized-hardware-configuration.md
+++ b/workloads/virtual-machines/virtualized-hardware-configuration.md
@@ -117,7 +117,7 @@ You can check list of available models [here](https://github.com/libvirt/libvirt
 
 > **Note:** CPU mode should not be mixed with CPU model.
 
-Setting the CPU mode is possible via `spec.domain.cpu.mode`. Setting the mode allows to achieve high performance by choosing `host-model` or `host-passthrough`.
+Setting the CPU mode is possible via `spec.domain.cpu.model`. Setting the mode allows to achieve high performance by choosing `host-model` or `host-passthrough`.
 
 ```yaml
 metadata:
@@ -125,7 +125,7 @@ metadata:
 spec:
   domain:
     cpu:
-      mode: host-passthrough
+      model: host-passthrough
 ...
 ```
 


### PR DESCRIPTION
The field for setting the cpu model is called `model` and not `mode`.

Fixes https://github.com/kubevirt/kubevirt/issues/1340.