### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Introduction
 
+!> **Warning:** This User Guide is going to be deprecated soon.  Please follow <http://kubevirt.io/docs/> for the further reference.
+
 !> **Note:** This is a heavy work in progress. We do our best to keep it in sync with released features. If you encounter any problem, please file an [issue](https://github.com/kubevirt/kubevirt/issues).
 
 [KubeVirt](http://kubevirt.io) is a Kubernetes add-on to run virtual machines \(VirtualMachineInstances\) on a Kubernetes cluster. This document is intended for users, and will guide you through installation and various features.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 !> **Warning:** This User Guide is going to be deprecated soon.  Please follow <http://kubevirt.io/docs/> for the further reference.
 
-!> **Note:** This is a heavy work in progress. We do our best to keep it in sync with released features. If you encounter any problem, please file an [issue](https://github.com/kubevirt/kubevirt/issues).
-
 [KubeVirt](http://kubevirt.io) is a Kubernetes add-on to run virtual machines \(VirtualMachineInstances\) on a Kubernetes cluster. This document is intended for users, and will guide you through installation and various features.
 
 **Read it at:** <http://docs.kubevirt.io>


### PR DESCRIPTION
A new reconciled [KubeVirt Documentation](http://kubevirt.io/docs/) (it was released as part of the new
[KubeVirt Web site](http://kubevirt.io)).  Since it is going to replace the [User Guide](https://kubevirt.io/user-guide/) in the near future, it is fair to add deprecation warning to the [User Guide front page](https://kubevirt.io/user-guide/#/).

The new [KubeVirt Documentation](http://kubevirt.io/docs/) is clearly based on the original [User Guide](https://kubevirt.io/user-guide/), but the contributors worked very hard over last month to sync the new docs with the recent KubeVirt features.  At this very moment, the new documentation represents an up-to-date superset of the legacy [User Guide](https://kubevirt.io/user-guide/).  From the UX perspective, it is essential to convey this message and to redirect KubeVirt users to the new documentation resource.