### PR TITLE
Fix link to kubevirt-incubator

### DIFF
--- a/additional-resources.md
+++ b/additional-resources.md
@@ -4,7 +4,7 @@
 
 The KubeVirt incubator is a place to give projects associated with KubeVirt a room to grow. These projects are monitored by KubeVirt maintainers, but might not be ripe enough yet to be a part of core KubeVirt.
 
-[https://github.com/kubernetes-incubator/](https://github.com/kubernetes-incubator/)
+[https://github.com/kubevirt-incubator/](https://github.com/kubevirt-incubator/)
 
 ## Try it out
 


### PR DESCRIPTION
Was referencing Kubernetes instead of kubevirt