### PR TITLE
Document what users can do with the "common templates" subproject

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -29,6 +29,7 @@
     * [Virtual Machine Replica Set](workloads/controllers/virtual-machine-replica-set.md)
   * [Templates](workloads/templates/README.md)
     * [Virtual Machine Creation](workloads/templates/vm-creation.md)
+    * [Working with Templates](workloads/templates/common-templates.md)
   * [Annotations and Labels](misc/annotations_and_labels.md)
   * [Cluster Monitoring](misc/monitoring.md)
 * [Additional resources](additional-resources.md)

--- a/workloads/templates/common-templates.md
+++ b/workloads/templates/common-templates.md
@@ -31,14 +31,16 @@ $ oc create -f https://github.com/kubevirt/common-templates/releases/download/$V
 ## Editable fields
 
 You can edit the fields of the templates which define the amount of resources which the VMs will receive.
-The list of fields includes:
 
-- spec.template.spec.domain.cpu.cores
-- spec.template.spec.domain.resources.requests.memory
-- spec.template.spec.domain.devices.disks
-- spec.template.spec.volumes
-- spec.template.spec.networks
+Each template can list a different set of fields that are to be considered editable.
+The fields are used as hints for the user interface, and also for other components in the cluster.
 
+The editable fields are taken from annotations in the template:
+```yaml
+metadata:
+  annotations:
+    template.cnv.io/editable: ...
+```
 
 ## Relationship between templates and VMs
 

--- a/workloads/templates/common-templates.md
+++ b/workloads/templates/common-templates.md
@@ -20,7 +20,7 @@ More documentation is available in the [common templates subproject](https://git
 ## Accessing the virtual machine templates
 
 If you installed KubeVirt using a supported method you should find the common templates preinstalled in the cluster.
-Should you want to upgrade the templates, or installed them from scratch, you can use one of the [supported release](https://github.com/kubevirt/common-templates/releases)
+Should you want to upgrade the templates, or install them from scratch, you can use one of the [supported releases](https://github.com/kubevirt/common-templates/releases)
 
 To install the templates:
 ```bash

--- a/workloads/templates/common-templates.md
+++ b/workloads/templates/common-templates.md
@@ -35,11 +35,33 @@ You can edit the fields of the templates which define the amount of resources wh
 Each template can list a different set of fields that are to be considered editable.
 The fields are used as hints for the user interface, and also for other components in the cluster.
 
-The editable fields are taken from annotations in the template:
+The editable fields are taken from annotations in the template. Here is a snippet presenting a couple of most
+commonly found editable fields:
+
 ```yaml
 metadata:
   annotations:
-    template.cnv.io/editable: ...
+    template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+```
+
+Each entry in the editable field list must be a [jsonpath](https://kubernetes.io/docs/reference/kubectl/jsonpath/).
+The actually editable field is the last entry (the "leaf") of the path. For example, the following minimal snippet highlights
+the fields which you can edit:
+```yaml
+objects:
+  spec:
+    template:
+      spec:
+        domain:
+          cpu:
+            cores:
+              VALUE # this is editable
+          resources:
+            requests:
+              memory:
+                VALUE # this is editable
 ```
 
 ## Relationship between templates and VMs

--- a/workloads/templates/common-templates.md
+++ b/workloads/templates/common-templates.md
@@ -5,13 +5,15 @@
 The KubeVirt projects provides a set of [templates](https://docs.okd.io/latest/dev_guide/templates.html) to create VMs to handle common usage scenarios.
 These templates provide a combination of some key factors that could be further customized and processed to have a Virtual Machine object.
 The key factors which define a template are
+
 - Workload
-most Virtual Machine should be *generic* to have maximum flexibility; the *highperformance* workload trades some of this flexibility to
-provide better performance
+  Most Virtual Machine should be *generic* to have maximum flexibility; the *highperformance* workload trades some of this flexibility to
+  provide better performances.
 - Guest Operating System (OS)
-Enable optimizations depending on the OS which is going to run on the guest.
+  This allow to ensure that the emulated hardware is compatible with the guest OS. Furthermore, it allows to maximize the stability
+  of the VM, and allows performance optimizations.
 - Size (flavor) 
-Amount of resources (CPU, memory) to allocate to the VM
+  Defines the amount of resources (CPU, memory) to allocate to the VM.
 
 More documentation is available in the [common templates subproject](https://github.com/kubevirt/common-templates)
 

--- a/workloads/templates/common-templates.md
+++ b/workloads/templates/common-templates.md
@@ -38,3 +38,18 @@ The list of fields includes:
 - spec.template.spec.domain.devices.disks
 - spec.template.spec.volumes
 - spec.template.spec.networks
+
+
+## Relationship between templates and VMs
+
+Once [processed](), the templates produce VM objects to be used in the cluster. The VMs produced from templates will have a `vm.cnv.io/template` label, whose
+value will be the name of the parent template, for example `fedora-generic-medium`:
+```yaml
+  metadata:
+    labels:
+      vm.cnv.io/template: fedora-generic-medium
+```
+This make it possible to query for all the VMs built from any template.
+
+Please note that, after the generation step, VM objects and template objects have no relationship with each other besides the aforementioned label (e.g. changes
+in templates do not automatically affect VMs, or vice versa).

--- a/workloads/templates/common-templates.md
+++ b/workloads/templates/common-templates.md
@@ -25,3 +25,14 @@ To install the templates:
 $ export VERSION="v0.3.1"
 $ oc create -f https://github.com/kubevirt/common-templates/releases/download/$VERSION/common-templates-$VERSION.yaml
 ```
+
+## Editable fields
+
+You can edit the fields of the templates which define the amount of resources which the VMs will receive.
+The list of fields includes:
+
+- spec.template.spec.domain.cpu.cores
+- spec.template.spec.domain.resources.requests.memory
+- spec.template.spec.domain.devices.disks
+- spec.template.spec.volumes
+- spec.template.spec.networks

--- a/workloads/templates/common-templates.md
+++ b/workloads/templates/common-templates.md
@@ -2,8 +2,8 @@
 
 ## What is a virtual machine template?
 
-The KubeVirt projects provides [templates](https://docs.okd.io/latest/dev_guide/templates.html) to create VMs to handle common scenarios.
-A template provides a combination of some key factors that could be further customized and processed to have a Virtual Machine object.
+The KubeVirt projects provides a set of [templates](https://docs.okd.io/latest/dev_guide/templates.html) to create VMs to handle common usage scenarios.
+These templates provide a combination of some key factors that could be further customized and processed to have a Virtual Machine object.
 The key factors which define a template are
 - Workload
 most Virtual Machine should be *generic* to have maximum flexibility; the *highperformance* workload trades some of this flexibility to

--- a/workloads/virtual-machines/common-templates.md
+++ b/workloads/virtual-machines/common-templates.md
@@ -1,0 +1,27 @@
+# Virtual machine templates
+
+## What is a virtual machine template?
+
+The KubeVirt projects provides [templates](https://docs.okd.io/latest/dev_guide/templates.html) to create VMs to handle common scenarios.
+A template provides a combination of some key factors that could be further customized and processed to have a Virtual Machine object.
+The key factors which define a template are
+- Workload
+most Virtual Machine should be *generic* to have maximum flexibility; the *highperformance* workload trades some of this flexibility to
+provide better performance
+- Guest Operating System (OS)
+Enable optimizations depending on the OS which is going to run on the guest.
+- Size (flavor) 
+Amount of resources (CPU, memory) to allocate to the VM
+
+More documentation is available in the [common templates subproject](https://github.com/kubevirt/common-templates)
+
+## Accessing the virtual machine templates
+
+If you installed KubeVirt using a supported method you should find the common templates preinstalled in the cluster.
+Should you want to upgrade the templates, or installed them from scratch, you can use one of the [supported release](https://github.com/kubevirt/common-templates/releases)
+
+To install the templates:
+```bash
+$ export VERSION="v0.3.1"
+$ oc create -f https://github.com/kubevirt/common-templates/releases/download/$VERSION/common-templates-$VERSION.yaml
+```


### PR DESCRIPTION
This is the initial batch of documentation. More is still to come (also from @sHaggYcaT ).
I'm submitting this PR now because, albeit not complete, the initial changes are self-sufficient and allow us to bootstrap the "common-templates.md" file, which will receive more content later.

CC @sHaggYcaT @MarSik for reviews/comments