### PR TITLE
Fix link to CPU models

### DIFF
--- a/workloads/virtual-machines/virtualized-hardware-configuration.md
+++ b/workloads/virtual-machines/virtualized-hardware-configuration.md
@@ -111,7 +111,7 @@ spec:
 ...
 ```
 
-You can check list of available models [here](https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml).
+You can check list of available models [here](https://github.com/libvirt/libvirt/blob/master/src/cpu_map/index.xml).
 
 #### CPU model special cases
 


### PR DESCRIPTION
Fixed broken link for CPU models that refers to a libvirt's github page. 