### PR TITLE
Update sriov documentation to reflect the latest sriovdp master

### DIFF
--- a/workloads/virtual-machines/interfaces-and-networks.md
+++ b/workloads/virtual-machines/interfaces-and-networks.md
@@ -352,11 +352,14 @@ data:
   feature-gates: "SRIOV"
 ```
 
+Information on how to set up Intel SR-IOV device plugin can be found
+[in their respective documentation](https://github.com/intel/sriov-network-device-plugin/blob/master/README.md).
+
 > **Note:** while the `sriov` mode is validated and tested using the Intel
 > SR-IOV device plugin, other plugins may add support for the same by setting
-> the `SRIOV-VF-PCI-ADDR` environment variable inside pods to a list of
+> the `PCIDEVICE_<resourceName>` environment variables inside pods to a list of
 > allocated PCI device IDs, as in:
-> SRIOV-VF-PCI-ADDR=0000:81:11.1,0000:81:11.2[,...]
+> PCIDEVICE_VENDOR_COM_RESOURCE_NAME=0000:81:11.1,0000:81:11.2[,...]
 
 > **Note:** as of the time of writing, in addition to attaching a VM to a
 > SR-IOV network, you have to also request corresponding devices from the


### PR DESCRIPTION
This is to align documentation with the kubevirt PR that adopts the
project to behavior expressed by the very latest sriovdp master:

https://github.com/kubevirt/kubevirt/pull/1692