### PR TITLE
Remove references to vmctl ServiceAccount from examples

### DIFF
--- a/workloads/virtual-machines/vmctl.md
+++ b/workloads/virtual-machines/vmctl.md
@@ -145,7 +145,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - "testvm"
-      serviceAccountName: vmctl
+        serviceAccountName: default
 ```
 
 This example would look for a VirtualMachine in the `default` namespace named
@@ -179,7 +179,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - "testvm"
-      serviceAccountName: vmctl
+        serviceAccountName: default
 ```
 
 This example would look for a VirtualMachine in the `default` namespace named


### PR DESCRIPTION
Examples used an undefined serviceAccount. For the purposes of documentation, assume the default account has the correct permissions.