### PR TITLE
Add status parameter to DataVolume example

### DIFF
--- a/workloads/virtual-machines/disks-and-volumes.md
+++ b/workloads/virtual-machines/disks-and-volumes.md
@@ -219,12 +219,12 @@ Use a PersistentVolumeClain when the VirtualMachineInstance's disk needs to pers
 
 A `PersistentVolume` can be in "filesystem" or "block" mode:
 
-- Filesystem: For KubeVirt to be able to consume the disk present on a PersistentVolume's filesystem, the disk must be named `disk.img` and be placed in the root path of the filesystem. Currently the disk is also required to be in raw format.  
-	> **Important:** The `disk.img` image file needs to be owned by the user-id `107` in order to avoid permission issues.  
-	
+- Filesystem: For KubeVirt to be able to consume the disk present on a PersistentVolume's filesystem, the disk must be named `disk.img` and be placed in the root path of the filesystem. Currently the disk is also required to be in raw format.
+	> **Important:** The `disk.img` image file needs to be owned by the user-id `107` in order to avoid permission issues.
+
 	> **Note:** If the `disk.img` image file has not been created manually before starting a VM then it will be created automatically
 	with the `PersistentVolumeClaim` size. Since not every storage provisioner provides volumes with the exact usable amount of space
-	as requested (e.g. due to filesystem overhead), KubeVirt tolerates up to 10% less available space. This can be configured with the 
+	as requested (e.g. due to filesystem overhead), KubeVirt tolerates up to 10% less available space. This can be configured with the
 	`pvc-tolerate-less-space-up-to-percent` value in the `kubevirt-config` ConfigMap.
 - Block: Use a block volume for consuming raw block devices. Note: you need to enable the BlockVolume feature gate.
 
@@ -526,6 +526,7 @@ spec:
       source:
         http:
           url: http://cdi-http-import-server.kube-system/images/alpine.iso
+    status: {}
 ```
 
 You can see the DataVolume defined in the dataVolumeTemplates section has two
@@ -539,7 +540,7 @@ When this VM manifest is posted to the cluster, as part of the launch flow a
 pvc will be created using the spec provided and the source data will be
 automatically imported into that pvc before the VM starts. When the VM is
 deleted, the storage provisioned by the DataVolume will automatically be
-deleted as well. 
+deleted as well.
 
 #### DataVolume VMI Behavior
 
@@ -582,7 +583,7 @@ spec:
   - name: volume1
     dataVolume:
       name: alpine-datavolume
-``` 
+```
 
 #### Enabling DataVolume support.
 


### PR DESCRIPTION
The dataVolumeTemplate example is missing the required status parameter.
It seems like you should be able to have a default there and leave it
out, but the type definition for the object does not include an
omitempty tag so it must be included.

Fixes GH Issue: 168