### PR TITLE
add socket and threads in templates and dedicated cpu

### DIFF
--- a/creating-virtual-machines/dedicated-cpu.adoc
+++ b/creating-virtual-machines/dedicated-cpu.adoc
@@ -42,17 +42,21 @@ pinned to the pCPUS that has been dedicated for the virt-launcher
 container.
 
 Expressing the desired amount of VMI’s vCPUs can be done by either
-setting the `spec.domain.cpu.cores` or
-`spec.domain.resources.requests.cpu` or
-`spec.domain.resources.limits.cpu` to a whole number, integer (e.g. 1,
-2, etc) indicating the number of vCPUs requested for the VMI.
+setting the guest topology in `spec.domain.cpu` (`sockets`, `cores`, `threads`) 
+or `spec.domain.resources.[requests/limits].cpu` to a whole number, integer (e.g. 1,
+2, etc) indicating the number of vCPUs requested for the VMI. Number of vCPUs is counted
+as `sockets * cores * threads` or if `spec.domain.cpu` is empty then it takes value from 
+`spec.domain.resources.requests.cpu` or `spec.domain.resources.limits.cpu`.
 
 _______________________________________________________________________________________________________________
-*Note:* Users should not specify both `spec.domain.cpu.cores` and
+*Note:* Users should not specify both `spec.domain.cpu` and
 `spec.domain.resources.[requests/limits].cpu`
 
 *Note:* `spec.domain.resources.requests.cpu` must be equal to
 `spec.domain.resources.limits.cpu`
+
+*Note:* Multiple cpu-bound microbenchmarks show a significant performance advantage when 
+using `spec.domain.cpu.sockets` instead of `spec.domain.cpu.cores`. 
 _______________________________________________________________________________________________________________
 
 All inconsistent requirements will be rejected.
@@ -64,7 +68,9 @@ kind: VirtualMachineInstance
 spec:
   domain:
     cpu:
-      cores: 2
+      sockets: 2
+      cores: 1
+      threads: 1
       dedicatedCpuPlacement: true
     resources:
       limits:

--- a/templates/common-templates.adoc
+++ b/templates/common-templates.adoc
@@ -59,7 +59,9 @@ a snippet presenting a couple of most commonly found editable fields:
 metadata:
   annotations:
     template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
       /objects[0].spec.template.spec.domain.resources.requests.memory
 ----
 
@@ -77,7 +79,11 @@ objects:
       spec:
         domain:
           cpu:
+            sockets:
+              VALUE # this is editable
             cores:
+              VALUE # this is editable
+            threads:
               VALUE # this is editable
           resources:
             requests:
@@ -130,7 +136,9 @@ items:
       spec:
         domain:
           cpu:
+            sockets: 1
             cores: 1
+            threads: 1
           devices:
             disks:
             - disk:


### PR DESCRIPTION
Added notice about sockets and threads in common templates and dedicated cpu section. 
@MarSik, @fabiand please can you review? Please feel free to point out, where the notice about sockets and threads is missing.