### PR TITLE
cleanup creationTimestamp: null

### DIFF
--- a/administration/image-upload.adoc
+++ b/administration/image-upload.adoc
@@ -113,7 +113,6 @@ cat <<EOF | kubectl apply -f -
 apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachineInstance
 metadata:
-  creationTimestamp: null
   name: cirros-vm
 spec:
   domain:

--- a/architecture/virtual-machine.adoc
+++ b/architecture/virtual-machine.adoc
@@ -155,7 +155,6 @@ Example
 apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachine
 metadata:
-  creationTimestamp: null
   labels:
     kubevirt.io/vm: vm-cirros
   name: vm-cirros
@@ -163,7 +162,6 @@ spec:
   running: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         kubevirt.io/vm: vm-cirros
     spec:

--- a/creating-virtual-machines/disks-and-volumes.adoc
+++ b/creating-virtual-machines/disks-and-volumes.adoc
@@ -558,7 +558,6 @@ to a VM.
 apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachineInstance
 metadata:
-  creationTimestamp: null
   labels:
     special: vmi-host-disk
   name: vmi-host-disk
@@ -676,7 +675,6 @@ DataVolumes have finished their clone and import phases.
 apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachineInstance
 metadata:
-  creationTimestamp: null
   labels:
     special: vmi-alpine-datavolume
   name: vmi-alpine-datavolume
@@ -776,7 +774,6 @@ Example: Attach the `configMap` to a VM and use `cloudInit` to mount the
 apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachineInstance
 metadata:
-  creationTimestamp: null
   labels:
     special: vmi-fedora
   name: vmi-fedora
@@ -853,7 +850,6 @@ Example: Attach the `secret` to a VM and use `cloudInit` to mount the
 apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachineInstance
 metadata:
-  creationTimestamp: null
   labels:
     special: vmi-fedora
   name: vmi-fedora
@@ -1024,7 +1020,6 @@ Shared IOThreads
 apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachineInstance
 metadata:
-  creationTimestamp: null
   labels:
     special: vmi-shared
   name: vmi-shared
@@ -1116,7 +1111,6 @@ Auto IOThreads
 apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachineInstance
 metadata:
-  creationTimestamp: null
   labels:
     special: vmi-shared
   name: vmi-shared
@@ -1299,7 +1293,6 @@ Example: force `writethrough` cache mode
 apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachineInstance
 metadata:
-  creationTimestamp: null
   labels:
     special: vmi-pvc
   name: vmi-pvc

--- a/creating-virtual-machines/virtio-win.adoc
+++ b/creating-virtual-machines/virtio-win.adoc
@@ -23,7 +23,6 @@ Example how to attach:
 apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachineInstance
 metadata:
-  creationTimestamp: null
   labels:
     special: vmi-virtio
   name: vmi-virtio

--- a/docs/latest/administration/image-upload.html
+++ b/docs/latest/administration/image-upload.html
@@ -294,7 +294,6 @@ following:</p>
 apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachineInstance
 metadata:
-  creationTimestamp: null
   name: cirros-vm
 spec:
   domain:

--- a/docs/latest/creating-virtual-machines/disks-and-volumes.html
+++ b/docs/latest/creating-virtual-machines/disks-and-volumes.html
@@ -921,7 +921,6 @@ DataVolumes have finished their clone and import phases.</p>
 <pre>apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachineInstance
 metadata:
-  creationTimestamp: null
   labels:
     special: vmi-alpine-datavolume
   name: vmi-alpine-datavolume


### PR DESCRIPTION
Cleanup _creationTimestamp: null_ from each kubevirt/kubernetes yaml manifest.

This MR was suggested in the conversation about another MR: https://github.com/kubevirt/user-guide/pull/150
