### PR TITLE
Added note about changed kubevirt account 

### DIFF
--- a/administration/intro.adoc
+++ b/administration/intro.adoc
@@ -181,6 +181,9 @@ https://docs.openshift.com/container-platform/3.7/admin_guide/manage_scc.html[SC
 needs to be added prior KubeVirt deployment:
 
 - When you use the stable deployment flow:
+____________________________________
+Important: Starting with version v0.15.0 please replace `kubevirt-privileged` with `kubevirt-handler`
+____________________________________
 [source,bash]
 ----
 $ oc adm policy add-scc-to-user privileged -n kubevirt -z kubevirt-privileged


### PR DESCRIPTION
Added note about changed kubevirt account which needs to be added to privileged SCC starting with Version 0.15.0.

I suggest another update once 0.15.0 is released, moving the new account into the normal documentation, and changing the note to mention the old account (or remove the note at all)

Signed-off-by: Marc Sluiter <msluiter@redhat.com>