### PR TITLE
Fix errors in virtio user guide

### DIFF
--- a/creating-virtual-machines/virtio-win.adoc
+++ b/creating-virtual-machines/virtio-win.adoc
@@ -128,6 +128,8 @@ spec:
           # Therefore virtioContainerDisk, must be after bootable disk.
           # Other option is to choose boot order explicitly:
           #  - https://kubevirt.io/api-reference/v0.13.2/definitions.html#_v1_disk
+          # NOTE: You either specify bootOrder explicitely or sort the items in
+          #       disks. You can not do both at the same time.
           # bootOrder: 2
           cdrom:
             bus: sata

--- a/creating-virtual-machines/virtio-win.adoc
+++ b/creating-virtual-machines/virtio-win.adoc
@@ -122,7 +122,7 @@ spec:
   domain:
     devices:
       disks:
-        - name: virtioContainerDisk
+        - name: virtiocontainerdisk
           # Any other disk you want to use, must go before virtioContainerDisk.
           # KubeVirt boots from disks in order ther are defined.
           # Therefore virtioContainerDisk, must be after bootable disk.
@@ -136,7 +136,7 @@ spec:
 volumes:
   - containerDisk:
       image: kubevirt/virtio-container-disk
-    name: virtioContainerDisk
+    name: virtiocontainerdisk
 ----
 
 Once you are done installing virtio drivers, you can remove virtio container disk

--- a/creating-virtual-machines/virtio-win.adoc
+++ b/creating-virtual-machines/virtio-win.adoc
@@ -130,7 +130,7 @@ spec:
           #  - https://kubevirt.io/api-reference/v0.13.2/definitions.html#_v1_disk
           # bootOrder: 2
           cdrom:
-            bus:sata
+            bus: sata
 volumes:
   - containerDisk:
       image: kubevirt/virtio-container-disk


### PR DESCRIPTION
Fixes issues in virtio example in user-guide: 
* missing space in example
* mixed case label
* provides clarification when to use bootOrder when mounting virtio

Fixes: #207

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/user-guide/210)
<!-- Reviewable:end -->
