### PR TITLE
Document live migration on node-drain

### DIFF
--- a/administration/live-migration.adoc
+++ b/administration/live-migration.adoc
@@ -100,8 +100,6 @@ Migration State:
     Target Pod:                   virt-launcher-testvmimcbjgw6zrzcmp8wpddvztvzm7x2k6cjbdgktwv8tkq
 ```
 
-
-
 ## Cancel live migration
 
 Live migration can also be canceled by simply deleting the migration object.
@@ -131,3 +129,28 @@ Migration State:
     Target Node Domain Detected:  true
     Target Pod:                   virt-launcher-testvmimcbjgw6zrzcmp8wpddvztvzm7x2k6cjbdgktwv8tkq
 ```
+
+## Changing Cluster Wide Migration Limits
+
+KubeVirt puts some limits in place, so that migrations don't overwhelm the
+cluster. By default it is configured to only run `5` migrations in parallel
+with an additional limit of a maximum  of `2` outbound migrations per node.
+Finally every migration is limited to a bandwidth of `64MiB/s`.
+
+These values can be change in the `kubevirt-config`:
+
+....
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevirt-config
+  namespace: kubevirt
+  labels:
+    kubevirt.io: ""
+data:
+  feature-gates: "LiveMigration"
+  migrations: |-
+    parallelMigrationsPerCluster: 5
+    parallelOutboundMigrationsPerNode: 2
+    bandwidthPerMigration: 64Mi
+....

--- a/administration/node-eviction.adoc
+++ b/administration/node-eviction.adoc
@@ -71,11 +71,7 @@ if the `kubevirt.io/drain:NoSchedule` taint is added to a nodes:
 [source,yaml]
 ----
 spec:
-  evictionPolicy:
-    taints:
-      - effect: NoSchedule
-        key: kubevirt.io/drain
-        strategy: LiveMigrate
+  evictionStrategy: LiveMigrate
 ----
 
 Here a full VMI:
@@ -88,11 +84,7 @@ metadata:
   name: testvmi-nocloud
 spec:
   terminationGracePeriodSeconds: 30
-  evictionPolicy:
-    taints:
-      - effect: NoSchedule
-        key: kubevirt.io/drain
-        strategy: LiveMigrate
+  evictionStrategy: LiveMigrate
   domain:
     resources:
       requests:
@@ -120,19 +112,61 @@ spec:
 Once the VMI is created, taint the node with
 
 ----
-kubectl taint nodes foo kubevirt.io/drain:NoSchedule
+kubectl taint nodes foo kubevirt.io/drain=draining:NoSchedule
 ----
 
 which will trigger a migration.
 
 Behind the scenes a *PodDisruptionBudget* is created for each VMI which has an
-*evictionPolicy* defined. This ensures that evictions will not blocked on these
+*evictionStrategy* defined. This ensures that evictions are be blocked on these
 VMIs and that we can guarantee that a VMI will be migrated instead of shut off.
 
-**Note:** While the *evictionPolicy* blocks the shutdown of VMIs during
+**Note:** While the *evictionStrategy* blocks the shutdown of VMIs during
 evictions, the live migration process is detached from the drain process
 itselve. Therefore it is necessary to add specified taints as part of the drain
 process explicitly, until we have a better integrated solution.
+
+By default KubeVirt will rewact with live migrations if the taint
+`kubevirt.io/drain:NoSchedule` is added to the node. It is possible to
+configure a different key in the `kubevirt-config` config map, by setting in
+the migration options the `nodeDrainTaintKey`:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevirt-config
+  namespace: kubevirt
+  labels:
+    kubevirt.io: ""
+data:
+  feature-gates: "LiveMigration"
+  migrations: |-
+    nodeDrainTaintKey: mytaint/drain
+----
+
+The default value is `kubevirt.io/drain`. With the change above migrations can
+be triggered with
+
+----
+kubectl taint nodes foo mytaint/drain=draining:NoSchedule
+----
+
+Here a full drain flow for nodes which includes VMI live migrations with the
+default setting:
+
+----
+kubectl taint nodes foo kubevirt.io/drain=draining:NoSchedule
+kubectl drain foo --delete-local-data --ignore-daemonsets=true --force
+----
+
+To make  the node schedulable again, run
+
+----
+kubectl taint nodes foo kubevirt.io/drain-
+kubectl uncordon foo
+----
 
 Re-enabling a Node after Eviction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -148,7 +182,7 @@ the following command must be run.
 
 or in the case of OpenShift
 
-`oc adm uncordon <node name`
+`oc adm uncordon <node name>`
 
 Shutting down a Node after Eviction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/administration/node-eviction.adoc
+++ b/administration/node-eviction.adoc
@@ -60,6 +60,80 @@ target node.
 
 `kubectl drain <node name> --delete-local-data --ignore-daemonsets=true --force`
 
+How to evacuate VMIs via Live Migration from a Node
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the *LiveMigration* feature gate is enabled, it is possible to specify an
+`evictionStrategy` on VMIs which will react with live-migrations on specific
+taints on nodes. The following snipped on a VMI ensures that the VMI is migrated
+if the `kubevirt.io/drain:NoSchedule` taint is added to a nodes:
+
+[source,yaml]
+----
+spec:
+  evictionPolicy:
+    taints:
+      - effect: NoSchedule
+        key: kubevirt.io/drain
+        strategy: LiveMigrate
+----
+
+Here a full VMI:
+
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachineInstance
+metadata:
+  name: testvmi-nocloud
+spec:
+  terminationGracePeriodSeconds: 30
+  evictionPolicy:
+    taints:
+      - effect: NoSchedule
+        key: kubevirt.io/drain
+        strategy: LiveMigrate
+  domain:
+    resources:
+      requests:
+        memory: 1024M
+    devices:
+      disks:
+      - name: containerdisk
+        disk:
+          bus: virtio
+      - disk:
+          bus: virtio
+        name: cloudinitdisk
+  volumes:
+  - name: containerdisk
+    containerDisk:
+      image: kubevirt/fedora-cloud-container-disk-demo:latest
+  - name: cloudinitdisk
+    cloudInitNoCloud:
+      userData: |-
+        #cloud-config
+        password: fedora
+        chpasswd: { expire: False }
+----
+
+Once the VMI is created, taint the node with
+
+----
+kubectl taint nodes foo kubevirt.io/drain:NoSchedule
+----
+
+which will trigger a migration.
+
+Behind the scenes a *PodDisruptionBudget* is created for each VMI which has an
+*evictionPolicy* defined. This ensures that evictions will not blocked on these
+VMIs and that we can guarantee that a VMI will be migrated instead of shut off.
+
+**Note:** While the *evictionPolicy* blocks the shutdown of VMIs during
+evictions, the live migration process is detached from the drain process
+itselve. Therefore it is necessary to add specified taints as part of the drain
+process explicitly, until we have a better integrated solution.
+
 Re-enabling a Node after Eviction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
* Document cluster-wide migration limits and how to change them
* Document `evictionPolicy` for live-migrate on drains