### PR TITLE
Fix copy paste errors in constaineridsk doc

### DIFF
--- a/creating-virtual-machines/disks-and-volumes.adoc
+++ b/creating-virtual-machines/disks-and-volumes.adoc
@@ -448,7 +448,8 @@ Example: Build container disk image:
 ----
 cat << END > Dockerfile
 FROM kubevirt/container-disk-v1alpha
-ADD fedora25.qcow2 /custom-disk-path
+RUN mkdir /custom-disk-path
+ADD fedora25.qcow2 /custom-disk-path/fedora25.qcow2
 END
 
 docker build -t vmidisks/fedora25:latest .
@@ -476,7 +477,7 @@ spec:
     - name: containerdisk
       containerDisk:
         image: vmidisks/fedora25:latest
-        path: /custom-disk-path/fedora.qcow2
+        path: /custom-disk-path/fedora25.qcow2
 ----
 
 emptyDisk


### PR DESCRIPTION
Fixes the copy paste error in ContainerDisk documentation for custom path.
This lead to confusion for users how to properly use the custom disk path.

Now it is copy paste friendly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/user-guide/247)
<!-- Reviewable:end -->
