### PR TITLE
Updating DNS doc

### DIFF
--- a/using-virtual-machines/dns.adoc
+++ b/using-virtual-machines/dns.adoc
@@ -38,7 +38,9 @@ spec:
         name: cloudinitdisk
       interfaces:
       - name: default
-        bridge: {}
+        masquerade: {}
+        ports:
+        - port: 22
     resources:
       requests:
         memory: 1024M

--- a/using-virtual-machines/dns.adoc
+++ b/using-virtual-machines/dns.adoc
@@ -36,10 +36,16 @@ spec:
       - disk:
           bus: virtio
         name: cloudinitdisk
+      interfaces:
+      - name: default
+        bridge: {}
     resources:
       requests:
         memory: 1024M
   terminationGracePeriodSeconds: 0
+  networks:
+  - name: default
+    pod: {}
   volumes:
   - name: containerdisk
     containerDisk:


### PR DESCRIPTION
A network and interface is required to be defined, or the VMI gets no IP
and thus none of the rest of the DNS example works.