### PR TITLE
Change examples with bridge to masquerade

### DIFF
--- a/creating-virtual-machines/interfaces-and-networks.adoc
+++ b/creating-virtual-machines/interfaces-and-networks.adoc
@@ -54,7 +54,7 @@ spec:
     devices:
       interfaces:
         - name: default
-          bridge: {}
+          masquerade: {}
   networks:
   - name: default
     pod: {} # Stock pod network
@@ -104,7 +104,7 @@ spec:
     devices:
       interfaces:
         - name: default
-          bridge: {}
+          masquerade: {}
           bootFileName: default_image.bin
           tftpServerName: tftp.example.com
           bootOrder: 1   # attempt to boot from an external tftp server
@@ -281,7 +281,7 @@ spec:
       interfaces:
         - name: default
           model: e1000 # expose e1000 NIC to the guest
-          bridge: {} # connect through a bridge
+          masquerade: {} # connect through a masquerade
           ports:
            - name: http
              port: 80
@@ -407,8 +407,9 @@ spec:
           bridge: {} # connect through a bridge
   networks:
   - name: red
-    pod: {}
-----
+    multus:
+      networkName: red
+-----
 
 At this time, `bridge` mode doesn’t support additional configuration
 fields.


### PR DESCRIPTION
in this PR we changed the example vm configuration
which had bridge as the default
binding method to masqurade.
That's regarding the issues discussed in detail here:
https://github.com/kubevirt/kubevirt/pull/2537
and here: https://github.com/kubevirt/kubevirt/pull/2493
We would like the examples to be consistent with
the changes suggested in those two PRs, and prevent from
a random user to copy-paste the examples and
receive an unexpected behavior.