### PR TITLE
Remove info about sriov feature gate

### DIFF
--- a/creating-virtual-machines/interfaces-and-networks.adoc
+++ b/creating-virtual-machines/interfaces-and-networks.adoc
@@ -574,23 +574,6 @@ spec:
       networkName: sriov-net-crd
 ----
 
-______________________________________________________________________________
-*Note:* you need to enable the SRIOV feature gate to use the feature. For
-example:
-______________________________________________________________________________
-
-....
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kubevirt-config
-  namespace: kube-system
-  labels:
-    kubevirt.io: ""
-data:
-  feature-gates: "SRIOV"
-....
-
 Information on how to set up Intel SR-IOV device plugin can be found
 https://github.com/intel/sriov-network-device-plugin/blob/master/README.md[in
 their respective documentation].


### PR DESCRIPTION
With https://github.com/kubevirt/kubevirt/pull/2546 sriov is enabled by default and there is no need of setting the feature gate. This PR removes the instructions about setting the gate. 