### PR TITLE
Update typo in installation guide

### DIFF
--- a/administration/intro.adoc
+++ b/administration/intro.adoc
@@ -325,7 +325,7 @@ $ kubectl delete -f https://github.com/kubevirt/kubevirt/releases/download/${REL
 ----
 
 ______________________________________________________________________________________________________________________________________________________
-Note: If by mistake you deleted the operator first, the KV custom resource will stuck in the `Terminatig` state,
+Note: If by mistake you deleted the operator first, the KV custom resource will stuck in the `Terminating` state,
 to fix it, delete manually finalizer from the resource.
 
 [source,bash]

--- a/docs/latest/administration/intro.html
+++ b/docs/latest/administration/intro.html
@@ -580,7 +580,7 @@ $ kubectl delete -f https://github.com/kubevirt/kubevirt/releases/download/${REL
 <div class="quoteblock">
 <blockquote>
 <div class="paragraph">
-<p>Note: If by mistake you deleted the operator first, the KV custom resource will stuck in the <code>Terminatig</code> state,
+<p>Note: If by mistake you deleted the operator first, the KV custom resource will stuck in the <code>Terminating</code> state,
 to fix it, delete manually finalizer from the resource.</p>
 </div>
 <div class="listingblock">


### PR DESCRIPTION
Installation guide had a small typo (Terminatig -> Terminating)