### PR TITLE
web-ui: Deprecate Web UI in favor of openshift/console

### DIFF
--- a/administration/api-validation.adoc
+++ b/administration/api-validation.adoc
@@ -61,11 +61,11 @@ development
 --admission-control='Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota'
 ....
 
-Enabling KubeVirt Admission Controller on OpenShift
+Enabling KubeVirt Admission Controller on OKD
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-OpenShift also requires the admission control webhooks to be enabled at
-install time. The process is slightly different though. With OpenShift,
+OKD also requires the admission control webhooks to be enabled at
+install time. The process is slightly different though. With OKD,
 we enable webhooks using an admission plugin.
 
 These admission control plugins can be configured in openshift-ansible

--- a/administration/intro.adoc
+++ b/administration/intro.adoc
@@ -4,7 +4,7 @@ Installation
 KubeVirt is a virtualization add-on to Kubernetes and this guide assumes
 that a Kubernetes cluster is already installed.
 
-If installed on OpenShift, the web console is extended for management of virtual machines.
+If installed on OKD, the web console is extended for management of virtual machines.
 
 Requirements
 ~~~~~~~~~~~~
@@ -80,7 +80,7 @@ To enable hugepages on Kubernetes, check the
 https://kubernetes.io/docs/tasks/manage-hugepages/scheduling-hugepages/[official
 documentation].
 
-To enable hugepages on OpenShift, check the
+To enable hugepages on OKD, check the
 https://docs.openshift.org/3.9/scaling_performance/managing_hugepages.html#huge-pages-prerequisites[official
 documentation].
 
@@ -143,7 +143,7 @@ a nodeSelector. For example, to restrict the DaemonSet to only nodes with the "r
 kubectl patch ds/virt-handler -n kubevirt -p '{"spec": {"template": {"spec": {"nodeSelector": {"region": "primary"}}}}}'
 ----
 
-Deploying on OpenShift
+Deploying on OKD
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The following
@@ -157,10 +157,10 @@ $ oc adm policy add-scc-to-user privileged -n kubevirt -z kubevirt-operator
 
 Once privileges are granted, the KubeVirt can be deployed as described above.
 
-Web user interface on OpenShift
+Web user interface on OKD
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-No additional steps are required to extend OpenShift's web console for KubeVirt.
+No additional steps are required to extend OKD's web console for KubeVirt.
 
 The virtualization extension is automatically enabled when KubeVirt deployment is detected.
 
@@ -219,7 +219,7 @@ $ kubectl virt <command>...
 From Service Catalog as an APB
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can find KubeVirt in the OpenShift Service Catalog and install it
+You can find KubeVirt in the OKD Service Catalog and install it
 from there. In order to do that please follow the documentation in the
 https://github.com/ansibleplaybookbundle/kubevirt-apb[KubeVirt APB
 repository].
@@ -229,7 +229,7 @@ Using Ansible playbooks
 
 The https://github.com/kubevirt/kubevirt-ansible[kubevirt-ansible]
 project provides a collection of playbooks that installs KubeVirt and
-it’s related components on top of OpenShift or Kubernetes clusters.
+it’s related components on top of OKD or Kubernetes clusters.
 
 Deploying from Source
 ~~~~~~~~~~~~~~~~~~~~~

--- a/administration/intro.adoc
+++ b/administration/intro.adoc
@@ -4,6 +4,8 @@ Installation
 KubeVirt is a virtualization add-on to Kubernetes and this guide assumes
 that a Kubernetes cluster is already installed.
 
+If installed on OpenShift, the web console is extended for management of virtual machines.
+
 Requirements
 ~~~~~~~~~~~~
 
@@ -155,6 +157,13 @@ $ oc adm policy add-scc-to-user privileged -n kubevirt -z kubevirt-operator
 
 Once privileges are granted, the KubeVirt can be deployed as described above.
 
+Web user interface on OpenShift
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+No additional steps are required to extend OpenShift's web console for KubeVirt.
+
+The virtualization extension is automatically enabled when KubeVirt deployment is detected.
+
 Client side `virtctl` deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -246,25 +255,6 @@ https://github.com/kubevirt/kubevirt-ansible/tree/master/playbooks#network[netwo
 playbook] installs these plugins by default.
 ______________________________________________________________________________________________________________________________________________________
 
-Installing Web User Interface (optional)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When the KubeVirt is installed on OpenShift, the Web User Interface can be used to administer the virtual
-machines and other entities in the cluster in addition to the command line tools.
-
-The Web UI is installed by default within the kubevirt-ansible flow as described above.
-
-The Web UI URL can be retrieved from its Route object:
-----
-$ oc get route console -n kubevirt-web-ui
-----
-
-For manual installation, see https://github.com/kubevirt/web-ui-operator/blob/master/README.md[the web-ui-operator README] file.
-
-For additional details, see the https://github.com/kubevirt/web-ui[Web User Interface project].
-
-______________________________________________________________________________________________________________________________________________________
-Note: Kubevirt Web UI ansible playbook can be found https://github.com/kubevirt/kubevirt-ansible/blob/master/playbooks/kubevirt_web_ui.yml[here].
-______________________________________________________________________________________________________________________________________________________
 
 Update
 ~~~~~~

--- a/administration/monitoring.adoc
+++ b/administration/monitoring.adoc
@@ -102,7 +102,7 @@ spec:
       insecureSkipVerify: true
 ----
 
-Integrating with the OpenShift cluster-monitoring-operator
+Integrating with the OKD cluster-monitoring-operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After the

--- a/administration/node-eviction.adoc
+++ b/administration/node-eviction.adoc
@@ -6,7 +6,7 @@ ensure that VirtualMachineInstances have been gracefully terminated
 before powering down the node. Since all VirtualMachineInstances are
 backed by a Pod, the recommended method of evicting
 VirtualMachineInstances is to use the *kubectl drain* command, or in the
-case of OpenShift the *oc adm drain* command.
+case of OKD the *oc adm drain* command.
 
 How to Evict all VMs on a Node
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -180,7 +180,7 @@ the following command must be run.
 
 `kubectl uncordon <node name>`
 
-or in the case of OpenShift
+or in the case of OKD.
 
 `oc adm uncordon <node name>`
 

--- a/creating-virtual-machines/dedicated-cpu.adoc
+++ b/creating-virtual-machines/dedicated-cpu.adoc
@@ -25,7 +25,7 @@ Additional information: *
 https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/[Enabling
 the CPU manager on Kubernetes] *
 https://docs.openshift.com/container-platform/3.10/scaling_performance/using_cpu_manager.html[Enabling
-the CPU manager on OpenShift] *
+the CPU manager on OKD] *
 https://kubernetes.io/blog/2018/07/24/feature-highlight-cpu-manager/[Kubernetes
 blog explaning the feature]
 

--- a/creating-virtual-machines/interfaces-and-networks.adoc
+++ b/creating-virtual-machines/interfaces-and-networks.adoc
@@ -328,7 +328,7 @@ spec:
 ----
 
 
-This approach may not work for all plugins. For example, OpenShift SDN is not
+This approach may not work for all plugins. For example, OKD SDN is not
 compatible with `tuning` plugin.
 
 * Plugins that handle custom MAC addresses natively: `ovs`.


### PR DESCRIPTION
The Web UI project is deprecated, the Web Console [1] is
extended for virtualization support.

[1] https://github.com/openshift/console