### PR TITLE
Update links to use kubevirt.io without www

### DIFF
--- a/creating-virtual-machines/disks-and-volumes.adoc
+++ b/creating-virtual-machines/disks-and-volumes.adoc
@@ -355,7 +355,7 @@ Currently, only `PersistentVolumeClaim` may be used as a backing store
 of the ephemeral volume.
 
 Up-to-date information on supported backing stores can be found in the
-http://www.kubevirt.io/api-reference/master/definitions.html#_v1_ephemeralvolumesource[KubeVirt
+http://kubevirt.io/api-reference/master/definitions.html#_v1_ephemeralvolumesource[KubeVirt
 API].
 
 [source,yaml]

--- a/using-virtual-machines/virtual-machine-replica-set.adoc
+++ b/using-virtual-machines/virtual-machine-replica-set.adoc
@@ -57,7 +57,7 @@ $ virtctl expose vmirs vmi-ephemeral --name vmiservice --port 27017 --target-por
 
 All service exposure options that apply to a VirtualMachineInstance
 apply to a VirtualMachineInstanceReplicaSet. See
-http://www.kubevirt.io/user-guide/#/workloads/virtual-machines/expose-service[Exposing
+http://kubevirt.io/user-guide/#/workloads/virtual-machines/expose-service[Exposing
 VirtualMachineInstance] for more details.
 
 When to use a VirtualMachineInstanceReplicaSet

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -23,7 +23,7 @@ Developer
 
 * Start contributing:
 https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
-* API Reference: http://www.kubevirt.io/api-reference/
+* API Reference: http://kubevirt.io/api-reference/
 
 
 Privacy


### PR DESCRIPTION
The alias `www.kubevirt.io` is currently broken (kubevirt/kubevirt.github.io#346), so the links that use it don't work.

This updates 3 links in the user guide to just use `kubevirt.io` instead of `www.kubevirt.io` as a workaround.

/kind bug

Fixes: #298 