### PR TITLE
update image upload doc to be more DataVolume centric

### DIFF
--- a/administration/image-upload.adoc
+++ b/administration/image-upload.adoc
@@ -5,12 +5,13 @@ The
 https://github.com/kubevirt/containerized-data-importer[Containerized
 Data Importer] (CDI) project provides facilities for enabling
 https://kubernetes.io/docs/concepts/storage/persistent-volumes/[Persistent
-Volume Claims] (PVCs) to be used as disks for KubeVirt VMs. The three
+Volume Claims] (PVCs) to be used as disks for KubeVirt VMs by way of
+https://github.com/kubevirt/containerized-data-importer/blob/master/doc/datavolumes.md[DataVolumes]. The three
 main CDI use cases are:
 
-* Import a disk image from a URL to a PVC (HTTP/S3)
-* Clone an an existing PVC
-* Upload a local disk image to a PVC
+* Import a disk image from a URL to a DataVolume (HTTP/S3)
+* Clone an existing PVC to a DataVolume
+* Upload a local disk image to a DataVolume
 
 This document deals with the third use case. So you should have CDI
 installed in your cluster, a VM disk that you’d like to upload, and
@@ -21,11 +22,10 @@ Install CDI
 
 Install the latest CDI release
 https://github.com/kubevirt/containerized-data-importer/releases[here]
-(currently v1.8.0)
 
 [source,bash]
 ----
-VERSION=v1.8.0
+VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
 kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml
 kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator-cr.yaml
 ----
@@ -69,23 +69,34 @@ virtctl has an image-upload command with the following options:
 [source,bash]
 ----
 virtctl image-upload --help
-Upload a VM image to a PersistentVolumeClaim.
+Upload a VM image to a DataVolume/PersistentVolumeClaim.
 
 Usage:
   virtctl image-upload [flags]
 
 Examples:
-  # Upload a local disk image to a newly created PersistentVolumeClaim:
-    virtctl image-upload --upload-proxy-url=https://cdi-uploadproxy.mycluster.com --pvc-name=upload-pvc --pvc-size=10Gi --image-path=/images/fedora28.qcow2
+  # Upload a local disk image to a newly created DataVolume:
+  virtctl image-upload dv dv-name --size=10Gi --image-path=/images/fedora30.qcow2
+
+  # Upload a local disk image to an existing DataVolume
+  virtctl image-upload dv dv-name --no-create --image-path=/images/fedora30.qcow2
+
+  # Upload a local disk image to an existing PersistentVolumeClaim
+  virtctl image-upload pvc pvc-name --image-path=/images/fedora30.qcow2
+
+  # Upload to a DataVolume with explicit URL to CDI Upload Proxy
+  virtctl image-upload dv dv-name --uploadproxy-url=https://cdi-uploadproxy.mycluster.com --image-path=/images/fedora30.qcow2
 
 Flags:
       --access-mode string       The access mode for the PVC. (default "ReadWriteOnce")
+      --block-volume             Create a PVC with VolumeMode=Block (default Filesystem).
   -h, --help                     help for image-upload
       --image-path string        Path to the local VM image.
       --insecure                 Allow insecure server connections when using HTTPS.
-      --no-create                Don't attempt to create a new PVC.
-      --pvc-name string          The destination PVC.
-      --pvc-size string          The size of the PVC to create (ex. 10Gi, 500Mi).
+      --no-create                Don't attempt to create a new DataVolume/PVC.
+      --pvc-name string          DEPRECATED - The destination DataVolume/PVC name.
+      --pvc-size string          DEPRECATED - The size of the PVC to create (ex. 10Gi, 500Mi).
+      --size string              The size of the DataVolume to create (ex. 10Gi, 500Mi).
       --storage-class string     The storage class for the PVC.
       --uploadproxy-url string   The URL of the cdi-upload proxy service.
       --wait-secs uint           Seconds to wait for upload pod to start. (default 60)
@@ -93,13 +104,13 @@ Flags:
 Use "virtctl options" for a list of global command-line options (applies to all commands).
 ----
 
-``virtctl image-upload'' works by creating a PVC of the requested size,
+``virtctl image-upload'' works by creating a DataVolume of the requested size,
 sending an `UploadTokenRequest` to the `cdi-apiserver`, and uploading
 the file to the `cdi-uploadproxy`.
 
 [source,bash]
 ----
-virtctl image-upload --pvc-name=cirros-vm-disk --pvc-size=500Mi --image-path=/home/mhenriks/images/cirros-0.4.0-x86_64-disk.img --uploadproxy-url=<url to upload proxy service>
+virtctl image-upload dv cirros-vm-disk --size=500Mi --image-path=/home/mhenriks/images/cirros-0.4.0-x86_64-disk.img --uploadproxy-url=<url to upload proxy service>
 ----
 
 Create a VirtualMachineInstance


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

`virtctl image-upload` will now create DataVolumes, so update doc accordingly.