### PR TITLE
document the IO and emulator threads pinning to a shared pCPUs

### DIFF
--- a/creation/dedicated-cpu.md
+++ b/creation/dedicated-cpu.md
@@ -98,6 +98,8 @@ order to enhance the real-time support in KubeVirt and provide improved
 latency, KubeVirt will allocate an additional dedicated CPU, exclusively
 for the emulator thread, to which it will be pinned. This will
 effectively "isolate" the emulator thread from the vCPUs of the VMI.
+In case `ioThreadsPolicy` is set to `auto` IOThreads will also be
+"isolated" and placed on the same physical CPU as the QEMU emulator thread.
 
 This functionality can be enabled by specifying
 `isolateEmulatorThread: true` inside VMI spec’s `Spec.Domain.CPU`

--- a/creation/disks-and-volumes.md
+++ b/creation/disks-and-volumes.md
@@ -940,6 +940,15 @@ them. In case there are more IOThreads than CPUs, each IOThread will be
 pinned to a CPU, in a round-robin fashion. Otherwise, when there are
 fewer IOThreads than CPU, each IOThread will be pinned to a set of CPUs.
 
+#### IOThreads with QEMU Emulator thread and Dedicated (pinned) CPUs
+
+To further improve the vCPUs latency, KubeVirt can allocate an
+additional dedicated physical CPU[1](creation/dedicated-cpu.md), exclusively for the emulator thread, to which it will
+be pinned. This will effectively "isolate" the emulator thread from the vCPUs
+of the VMI. When `ioThreadsPolicy` is set to `auto` IOThreads will also be
+"isolated" from the vCPUs and placed on the same physical CPU as the QEMU
+emulator thread.
+
 ### Examples
 
 #### Shared IOThreads


### PR DESCRIPTION
Document how IOThreads will be pinned to the same pCPUs as the QEMU emulator thread on VMIs with dedicated CPUs.

Related to kubevirt/kubevirt#3103
Signed-off-by: Vladik Romanovsky <vromanso@redhat.com>