### PR TITLE
clarify better which upgrade paths are possible

### DIFF
--- a/installation/updating-and-deleting-installs.md
+++ b/installation/updating-and-deleting-installs.md
@@ -6,6 +6,14 @@ Zero downtime rolling updates are supported starting with release
 
 > Note: Updating is only supported from N-1 to N release.
 
+Examples:
+
+v0.17.0 to v0.18.0, 
+v0.17.1 to v0.18.2,
+v0.17.2 to v0.17.4
+
+are all valid update paths.
+
 Updates are triggered one of two ways.
 
 1.  By changing the imageTag value in the KubeVirt CR’s spec.


### PR DESCRIPTION
The text currently talks about 

> Note: Updating is only supported from N-1 to N release.

But it is not clear how N maps to a release pattern of "vX.Y.Z".
It is at least not clarified in this context.

The change proposed here is just one interpretation and meant as a starting point for the conversation.

Is the general idea to be able to update to the next Y version, regardless of Z?