### PR TITLE
remove references to kubevirt-config ConfigMap

### DIFF
--- a/creation/dedicated-cpu.md
+++ b/creation/dedicated-cpu.md
@@ -127,7 +127,7 @@ At this time, [Kubernetes doesn’t label the
 nodes](https://github.com/kubernetes/kubernetes/issues/66525) that has
 CPU manager running on it.
 
-KubeVirt has a mechansim to identify which nodes has the CPU manager
+KubeVirt has a mechanism to identify which nodes has the CPU manager
 running and manually add a `cpumanager=true` label. This label will be
 removed when KubeVirt will identify that CPU manager is no longer
 running on the node. This automatic identification should be viewed as a
@@ -146,34 +146,44 @@ running.
 
 ### Enabling the CPU Manager automatic identification feature gate
 
-To enable the automatic idetification, user may expand the
-`feature-gates` field in the kubevirt-config config map by adding the
+To enable the automatic identification, user may expand the
+`featureGates` field in the KubeVirt CR by adding the
 `CPUManager` to it.
 
-    apiVersion: v1
-    kind: ConfigMap
+```
+    apiVersion: kubevirt.io/v1alpha3
+    kind: Kubevirt
     metadata:
-      name: kubevirt-config
+      name: kubevirt
       namespace: kubevirt
-      labels:
-        kubevirt.io: ""
-    data:
-      feature-gates: "CPUManager"
+    spec:
+      ...
+      configuration:
+        developerConfiguration:
+          featureGates:
+            - "CPUManager"
+```
 
-Alternatively, users can edit an existing kubevirt-config:
+Alternatively, users can edit an existing kubevirt:
 
-`kubectl edit configmap kubevirt-config -n kubevirt`
+`kubectl edit kubevirt kubevirt -n kubevirt`
 
+```
     ...
-    data:
-      feature-gates: "DataVolumes,CPUManager"
+    spec:
+      configuration:
+        developerConfiguration:
+          featureGates:
+            - "DataVolumes"
+            - "CPUManager"
+```
 
 Sidecar containers and CPU allocation overhead
 ----------------------------------------------
 
 **Note:** In order to run sidecar containers, KubeVirt requires the
 `Sidecar` feature gate to be enabled by adding `Sidecar` to the
-`kubevirt-config` ConfigMap’s `feature-gates` field.
+`kubevirt` CR's `configuration.developerConfiguration.featureGates` field.
 
 According to the Kubernetes CPU manager model, in order the POD would
 reach the required QOS level `Guaranteed`, all containers in the POD

--- a/creation/devices.md
+++ b/creation/devices.md
@@ -129,20 +129,24 @@ The following VM will have a CPU with `3` cores:
 
 ### Enabling cpu compatibility enforcement
 
-To enable the cpu compatibility enforcement, user may expand the
-`feature-gates` field in the kubevirt-config config map by adding the
+To enable the CPU compatibility enforcement, user may expand the
+`featureGates` field in the KubeVirt CR by adding the
 `CPUNodeDiscovery` to it.
 
-    apiVersion: v1
-    kind: ConfigMap
+```
+    apiVersion: kubevirt.io/v1alpha3
+    kind: Kubevirt
     metadata:
-      name: kubevirt-config
+      name: kubevirt
       namespace: kubevirt
-      labels:
-        kubevirt.io: ""
-    data:
-      feature-gates: "CPUNodeDiscovery"
+    spec:
+      ...
+      configuration:
+        developerConfiguration:
+          featureGates:
+            - "CPUNodeDiscovery"
     ...
+```
 
 This feature-gate allows kubevirt to take VM cpu model and cpu features
 and create node selectors from them. With these node selectors, VM can
@@ -226,19 +230,21 @@ model, then no node selector is created.
 
 #### Enabling default cluster cpu model
 
-To enable the default cpu model, user may add the `default-cpu-model`
-field in the kubevirt-config config map.
+To enable the default cpu model, user may add the `cpuModel`
+field in the KubeVirt CR.
 
-    apiVersion: v1
-    kind: ConfigMap
+```
+    apiVersion: kubevirt.io/v1alpha3
+    kind: KubeVirt
     metadata:
-      name: kubevirt-config
+      name: kubevirt
       namespace: kubevirt
-      labels:
-        kubevirt.io: ""
-    data:
-      default-cpu-model: "EPYC"
+    spec:
+      ...
+      configuration:
+        cpuModel: "EPYC"
     ...
+```
 
 Default CPU model is set when vmi doesn’t have any cpu model. When vmi
 has cpu model set, then vmi’s cpu model is preferred. When default cpu

--- a/creation/disks-and-volumes.md
+++ b/creation/disks-and-volumes.md
@@ -290,8 +290,8 @@ A `PersistentVolume` can be in “filesystem” or “block” mode:
     > every storage provisioner provides volumes with the exact usable
     > amount of space as requested (e.g. due to filesystem overhead),
     > KubeVirt tolerates up to 10% less available space. This can be
-    > configured with the `pvc-tolerate-less-space-up-to-percent` value
-    > in the `kubevirt-config` ConfigMap.
+    > configured with the `configuration.developmentConfiguration.pvcTolerateLessSpaceUpToPercent` value
+    > in the `kubevirt` custom resource.
 
 -   Block: Use a block volume for consuming raw block devices. Note: you
     need to enable the BlockVolume feature gate.
@@ -427,12 +427,7 @@ DataVolumes have finished their clone and import phases.
 A DataVolume is a custom resource provided by the Containerized Data
 Importer (CDI) project. KubeVirt integrates with CDI in order to provide
 users a workflow for dynamically creating PVCs and importing data into
-those PVCs.
-
-In order to take advantage of the DataVolume volume source on a VM or
-VMI, the **DataVolumes** feature gate must be enabled in the
-**kubevirt-config** config map before KubeVirt is installed. CDI must
-also be installed.
+those PVCs. CDI is required to be installed.
 
 **Installing CDI**
 
@@ -441,29 +436,6 @@ page](https://github.com/kubevirt/containerized-data-importer/releases)
 
 Pick the latest stable release and post the corresponding
 cdi-controller-deployment.yaml manifest to your cluster.
-
-**Enabling the DataVolumes feature gate**
-
-Below is an example of how to enable DataVolume support using the
-kubevirt-config config map.
-
-    cat <<EOF | kubectl create -f -
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: kubevirt-config
-      namespace: kubevirt
-      labels:
-        kubevirt.io: ""
-    data:
-      feature-gates: "DataVolumes"
-    EOF
-
-This config map assumes KubeVirt will be installed in the kubevirt
-namespace. Change the namespace to suite your installation.
-
-First post the ConfigMap above, then install KubeVirt. At that point
-DataVolume integration will be enabled.
 
 ### ephemeral
 

--- a/creation/guest-operating-system-information.md
+++ b/creation/guest-operating-system-information.md
@@ -175,23 +175,33 @@ backward compatibility and because they depend on the
 [node-feature-discovery](https://github.com/kubernetes-sigs/node-feature-discovery)
 and on extra configuration.
 
-To enable strict host checking, the user may expand the `feature-gates`
-field in the kubevirt-config config map by adding the
-`HypervStrictCheck` to it.
+To enable strict host checking, the user may expand the `featureGates`
+field in the KubeVirt CR by adding the `HypervStrictCheck` to it.
 
-    apiVersion: v1
-    kind: ConfigMap
+```
+    apiVersion: kubevirt.io/v1alpha3
+    kind: Kubevirt
     metadata:
-      name: kubevirt-config
+      name: kubevirt
       namespace: kubevirt
-      labels:
-        kubevirt.io: ""
-    data:
-      feature-gates: "HypervStrictCheck"
+    spec:
+      ...
+      configuration:
+        developerConfiguration:
+          featureGates:
+            - "HypervStrictCheck"
+```
 
-Alternatively, users can edit an existing kubevirt-config:
+Alternatively, users can edit an existing kubevirt CR:
 
-`kubectl edit configmap kubevirt-config -n kubevirt`
+`kubectl edit kubevirt kubevirt -n kubevirt`
 
-    data:
-      feature-gates: "HypervStrictCheck,CPUManager"
+```
+    ...
+    spec:
+      configuration:
+        developerConfiguration:
+          featureGates:
+            - "HypervStrictCheck"
+            - "CPUManager"
+```      

--- a/creation/interfaces-and-networks.md
+++ b/creation/interfaces-and-networks.md
@@ -416,15 +416,15 @@ fields.
 > networks via a designated configuration flag. To achieve it, the admin
 > should set the following option to `false`:
 
-    apiVersion: v1
-    kind: ConfigMap
+    apiVersion: kubevirt.io/v1alpha3
+    kind: Kubevirt
     metadata:
-      name: kubevirt-config
+      name: kubevirt
       namespace: kubevirt
-      labels:
-        kubevirt.io: ""
-    data:
-      permitBridgeInterfaceOnPodNetwork: "false"
+    spec:
+      configuration:
+        networkConfiguration:
+          permitBridgeInterfaceOnPodNetwork: "false"
 
 > **Note:** binding the pod network using `bridge` interface type may
 > cause issues. Other than the third-party issue mentioned in the above

--- a/installation/authorization.md
+++ b/installation/authorization.md
@@ -42,14 +42,13 @@ all KubeVirt resources, including the ability to delete collections of
 resources.
 
 The admin role also grants users access to view and modify the KubeVirt
-runtime config. This config exists within a configmap called
-**kubevirt-config** in the namespace the KubeVirt components are
-running.
+runtime config. This config exists within the Kubevirt Custom Resource under
+the `configuration` key in the namespace the KubeVirt operator is running.
 
 > *NOTE* Users are only guaranteed the ability to modify the kubevirt
 > runtime configuration if a ClusterRoleBinding is used. A RoleBinding
-> will work to provide kubevirt-config access only if the RoleBinding
-> targets the same namespace the kubevirt-config exists in.
+> will work to provide kubevirt CR access only if the RoleBinding
+> targets the same namespace that the kubevirt CR exists in.
 
 ### Binding Default ClusterRoles to Users
 
@@ -131,12 +130,3 @@ this example role.
           - list
           - watch
           - deletecollection
-      - apiGroups: [""]
-        resources:
-          - configmaps
-        resourceNames:
-          - kubevirt-config
-        verbs:
-          - update
-          - get
-          - patch

--- a/installation/live-migration.md
+++ b/installation/live-migration.md
@@ -7,30 +7,37 @@ continues to run and remain accessible.
 ## Enabling the live-migration support
 
 Live migration must be enabled in the feature gates to be supported. The
-`feature-gates` field in the kubevirt-config config map can be expanded
+`featureGates` field in the KubeVirt CR can be expanded
 by adding the `LiveMigration` to it.
 
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kubevirt-config
-  namespace: kubevirt
-  labels:
-    kubevirt.io: ""
-data:
-  feature-gates: "LiveMigration"
+```
+    apiVersion: kubevirt.io/v1alpha3
+    kind: Kubevirt
+    metadata:
+      name: kubevirt
+      namespace: kubevirt
+    spec:
+      ...
+      configuration:
+        developerConfiguration:
+          featureGates:
+            - "LiveMigration"
 ```
 
-Alternatively, existing kubevirt-config can be altered:
+Alternatively, the existing kubevirt CR can be altered:
 
 ```sh
-kubectl edit configmap kubevirt-config -n kubevirt
+kubectl edit kubevirt kubevirt -n kubevirt
 ```
 
-```yaml
-data:
-  feature-gates: "DataVolumes,LiveMigration"
+```
+    ...
+    spec:
+      configuration:
+        developerConfiguration:
+          featureGates:
+            - "DataVolumes"
+            - "LiveMigration"
 ```
 
 ## Limitations
@@ -149,24 +156,25 @@ parallel with an additional limit of a maximum of `2` outbound
 migrations per node. Finally, every migration is limited to a bandwidth
 of `64MiB/s`.
 
-These values can be change in the `kubevirt-config`:
+These values can be change in the `kubevirt` CR:
 
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kubevirt-config
-  namespace: kubevirt
-  labels:
-    kubevirt.io: ""
-data:
-  feature-gates: "LiveMigration"
-  migrations: |-
-    parallelMigrationsPerCluster: 5
-    parallelOutboundMigrationsPerNode: 2
-    bandwidthPerMigration: 64Mi
-    completionTimeoutPerGiB: 800
-    progressTimeout: 150
+```
+    apiVersion: kubevirt.io/v1alpha3
+    kind: Kubevirt
+    metadata:
+      name: kubevirt
+      namespace: kubevirt
+    spec:
+      configuration:
+        developerConfiguration:
+          featureGates:
+            - "LiveMigration"
+        migrationConfiguration:
+          parallelMigrationsPerCluster: 5
+          parallelOutboundMigrationsPerNode: 2
+          bandwidthPerMigration: 64Mi
+          completionTimeoutPerGiB: 800
+          progressTimeout: 150
 ```
 
 # Migration timeouts

--- a/installation/node-eviction.md
+++ b/installation/node-eviction.md
@@ -127,20 +127,21 @@ solution.
 
 By default KubeVirt will trigger live migrations if the taint
 `kubevirt.io/drain:NoSchedule` is added to the node. It is possible to
-configure a different key in the `kubevirt-config` config map, by
-setting in the migration options the `nodeDrainTaintKey`:
+configure a different key in the `kubevirt` CR, by
+setting the migration option `nodeDrainTaintKey`:
 
-    apiVersion: v1
-    kind: ConfigMap
+    apiVersion: kubevirt.io/v1alpha3
+    kind: Kubevirt
     metadata:
-      name: kubevirt-config
+      name: kubevirt
       namespace: kubevirt
-      labels:
-        kubevirt.io: ""
-    data:
-      feature-gates: "LiveMigration"
-      migrations: |-
-        nodeDrainTaintKey: mytaint/drain
+    spec:
+      configuration:
+        developerConfiguration:
+          featureGates:
+            - "LiveMigration"
+        migrationConfiguration:
+          nodeDrainTaintKey: mytaint/drain
 
 The default value is `kubevirt.io/drain`. With the change above
 migrations can be triggered with

--- a/usage/overcommit.md
+++ b/usage/overcommit.md
@@ -94,8 +94,8 @@ VMI in case the node gets under memory pressure.
 Implicit memory overcommit is disabled by default. This means that when
 memory request is not specified, it is set to match
 `spec.domain.memory.guest`. However, it can be enabled using
-`memory-overcommit` in the `kubevirt-config`. For example, by setting
-`memory-overcommit: "150"` we define that when memory request is not
+`spec.configuration.developerConfiguration.memoryOvercommit` in the `kubevirt` CR. For example, by setting
+`memoryOvercommit: "150"` we define that when memory request is not
 explicitly set, it will be implicitly set to achieve memory overcommit
 of 150%. For instance, when `spec.domain.memory.guest: 3072M`, memory
 request is set to 2048M, if omitted. Note that the actual memory request


### PR DESCRIPTION
This update shows the new way to configure kubevirt based on the PR https://github.com/kubevirt/kubevirt/pull/3455