### PR TITLE
fix reference to non existing CDI install manifest

### DIFF
--- a/installation/image-upload.md
+++ b/installation/image-upload.md
@@ -27,7 +27,7 @@ Install the latest CDI release
 
     VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
     kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml
-    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator-cr.yaml
+    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-cr.yaml
 
 ### Expose cdi-uploadproxy service
 


### PR DESCRIPTION
`cdi-operator-cr.yaml` was renamed to `cd-cr.yaml` awhile back

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

