### PR TITLE
interfaces: drop Genie

### DIFF
--- a/creation/interfaces-and-networks.md
+++ b/creation/interfaces-and-networks.md
@@ -51,10 +51,6 @@ fields:
 <td><p><code>multus</code></p></td>
 <td><p>Secondary network provided using Multus</p></td>
 </tr>
-<tr class="odd">
-<td><p><code>genie</code></p></td>
-<td><p>Secondary network provided using Genie</p></td>
-</tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
https://github.com/kubevirt/kubevirt/pull/3206 has dropped support for Genie. We should drop it from the user guide, too.