### PR TITLE
networks: masquerade: default is forward all ports

### DIFF
--- a/creation/interfaces-and-networks.md
+++ b/creation/interfaces-and-networks.md
@@ -464,11 +464,12 @@ Wiki](https://wiki.qemu.org/Documentation/Networking#User_Networking_.28SLIRP.29
 
 In `masquerade` mode, KubeVirt allocates internal IP addresses to
 virtual machines and hides them behind NAT. All the traffic exiting
-virtual machines is "NAT’ed" using pod IP addresses. A virtual machine
+virtual machines is "NAT’ed" using pod IP addresses. A guest operating system
 should be configured to use DHCP to acquire IPv4 addresses.
 
-To allow traffic into virtual machines, the template `ports` section of
-the interface should be configured as follows.
+To allow traffic of specific ports into virtual machines, the template `ports` section of
+the interface should be configured as follows. If the `ports` section is missing,
+all ports forwarded into the VM.
 
     kind: VM
     spec:


### PR DESCRIPTION
If `ports` are completely missing from a `masquerade` interface, all traffic is forwarded into the VM.
This was introduced in https://github.com/kubevirt/kubevirt/pull/2331 but not enshrined in the docs yet.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>