### PR TITLE
Fix the CDI CR file name in installation guide

### DIFF
--- a/installation/image-upload.md
+++ b/installation/image-upload.md
@@ -27,7 +27,7 @@ Install the latest CDI release
 
     VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
     kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml
-    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator-cr.yaml
+    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-cr.yaml
 
 ### Expose cdi-uploadproxy service
 


### PR DESCRIPTION
Fix the CDI CR name
`# wget https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator-cr.yaml
--2020-09-07 05:02:31--  https://github.com/kubevirt/containerized-data-importer/releases/download/v1.22.0/cdi-operator-cr.yaml
Resolving github.com (github.com)... 13.250.177.223
Connecting to github.com (github.com)|13.250.177.223|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2020-09-07 05:02:32 ERROR 404: Not Found.`

Signed-off-by: Yan Du <yadu@redhat.com>
