### PR TITLE
Initial commit for OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,43 @@
+filters:
+  ".*":
+    reviewers:
+      - davidvossel
+      - vladikr
+      - rmohr
+      - stu-gott
+      - fabiand
+      - codificat
+      - danielBelenky
+      - AlonaKaplan
+      - dhiller
+      - jean-edouard
+      - ashleyschuett
+      - mhenriks
+      - phoracek
+      - codificat
+      - mazzystr
+      - hroyrh
+    approvers:
+      - davidvossel
+      - vladikr
+      - rmohr
+      - stu-gott
+      - fabiand
+      - codificat
+      - danielBelenky
+      - AlonaKaplan
+      - dhiller
+      - jean-edouard
+      - ashleyschuett
+      - mhenriks
+      - phoracek
+      - codificat
+      - mazzystr
+      - hroyrh
+
+  "^docs/.*":
+    labels:
+      - kind/documentation
+  "^site/.*":
+    labels:
+      - kind/website


### PR DESCRIPTION
Initial commit for OWNERS file

note: the tagging is set to the future user of mkdocs which will use directories docs and site.

See user-guide [issues/359](https://github.com/kubevirt/user-guide/issues/359)