### PR TITLE
kubectl autoscale works with VMIRS a long time now

### DIFF
--- a/usage/virtual-machine-replica-set.md
+++ b/usage/virtual-machine-replica-set.md
@@ -243,7 +243,7 @@ reference it in the spec of the autoscaler:
       maxReplicas: 10
       targetCPUUtilizationPercentage: 50
 
-Right now `kubectl autoscale` does not work with Custom Resources. Only
-the declarative form of writing the HPA yaml manually and posting it via
-`kubectl
-create` is supported.
+
+or use `kubectl autoscale` to define the HPA via the commandline:
+
+    $ kubectl autoscale vmirs vmi-replicaset-cirros --min=3 --max=10


### PR DESCRIPTION
Kubectl supports the `autoscale` command now for quite some time on CRDs: https://github.com/kubernetes/kubernetes/pull/72678.