### PR TITLE
Fix manifest file name

### DIFF
--- a/installation/image-upload.md
+++ b/installation/image-upload.md
@@ -27,7 +27,7 @@ Install the latest CDI release
 
     VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
     kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml
-    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator-cr.yaml
+    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-cr.yaml
 
 ### Expose cdi-uploadproxy service
 


### PR DESCRIPTION
Current documentation to install CDI ([here](https://kubevirt.io/user-guide/#/installation/image-upload?id=install-cdi)) suggests deploying the `cdi-operator-cr.yaml` manifest. The correct file name should be `cdi-cr.yaml`, based on assets specified in https://github.com/kubevirt/containerized-data-importer/releases.
