### PR TITLE
user-guide, sriov: note about dedicatedCpuPlacement

### DIFF
--- a/creation/interfaces-and-networks.md
+++ b/creation/interfaces-and-networks.md
@@ -736,6 +736,9 @@ spec:
 > **Note:** for some NICs (e.g. Mellanox), the kernel module needs to be
 > installed in the guest VM.
 
+> **Note:** Placement on dedicated CPUs can only be achieved if the Kubernetes CPU manager is running on the SR-IOV capable workers.
+> For further details please refer to the [dedicated cpu resources documentation](https://kubevirt.io/user-guide/#/creation/dedicated-cpu).
+
 ### macvtap
 
 In `macvtap` mode, virtual machines are directly exposed to the Kubernetes


### PR DESCRIPTION
It is not possible to enable dedicatedCpuPlacement without
cpumanager enabled. Since we advertise the use of dedicatedCpuPlacement
in our sriov-vmi example, we should note the user about this dependency.

Signed-off-by: alonSadan <asadan@redhat.com>