### PR TITLE
datavolume: Refer to the proper volume name

### DIFF
--- a/creation/disks-and-volumes.md
+++ b/creation/disks-and-volumes.md
@@ -410,7 +410,7 @@ DataVolumes have finished their clone and import phases.
           disks:
           - disk:
               bus: virtio
-            name: disk1
+            name: volume1
         machine:
           type: ""
         resources:


### PR DESCRIPTION
Small fix: in the example yaml the `disk name` refers to the `disk1` volume while the name of the volume is defined as `volume1`.