### PR TITLE
fix typo

### DIFF
--- a/creation/cloud-init.md
+++ b/creation/cloud-init.md
@@ -119,7 +119,7 @@ device.
         - name: cloudinitdisk
           cloudInitNoCloud:
             userData: |
-              ssh-authorized-keys:
+              ssh_authorized_keys:
                 - ssh-rsa AAAAB3NzaK8L93bWxnyp test@test.com
 
     END


### PR DESCRIPTION
* ref. https://cloudinit.readthedocs.io/en/latest/topics/examples.html :L32

```
    ssh_authorized_keys:
```