### PR TITLE
Fix failing links in content

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ avoid confusing and contradictory states, these fields are mutually
 exclusive.
 
 An extended explanation of `spec.runStrategy` vs `spec.running` can be
-found in [Run Strategies](virtual_machines/run_strategies.md)
+found in [Run Strategies](../virtual_machines/run_strategies)
 
 ### Starting and stopping
 
@@ -117,7 +117,7 @@ after the VirtualMachine was created, but before it started:
 
 All service exposure options that apply to a VirtualMachineInstance apply to a VirtualMachine.
 
-See [Service Objects](virtual_machines/service_objects.md) for more details.
+See [Service Objects](../virtual_machines/service_objects) for more details.
 
 ## When to use a VirtualMachine
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ avoid confusing and contradictory states, these fields are mutually
 exclusive.
 
 An extended explanation of `spec.runStrategy` vs `spec.running` can be
-found in [Run Strategies](creation/run-strategies.md)
+found in [Run Strategies](virtual_machines/run_strategies.md)
 
 ### Starting and stopping
 
@@ -115,10 +115,9 @@ after the VirtualMachine was created, but before it started:
 
     $ virtctl expose virtualmachine vmi-ephemeral --name vmiservice --port 27017 --target-port 22
 
-All service exposure options that apply to a VirtualMachineInstance
-apply to a VirtualMachine.
+All service exposure options that apply to a VirtualMachineInstance apply to a VirtualMachine.
 
-See [Network Service Integration](usage/network-service-integration.md) for more details.
+See [Service Objects](virtual_machines/service_objects.md) for more details.
 
 ## When to use a VirtualMachine
 

--- a/docs/virtual_machines/.pages
+++ b/docs/virtual_machines/.pages
@@ -9,7 +9,7 @@ nav:
   - interfaces_and_networks.md
   - networkpolicy.md
   - host-devices.md
-  - windows_wirtio_drivers.md
+  - windows_virtio_drivers.md
   - guest_operating_system_information.md
   - guest_agent_information.md
   - liveness_and_readiness_probes.md

--- a/docs/virtual_machines/disks_and_volumes.md
+++ b/docs/virtual_machines/disks_and_volumes.md
@@ -944,7 +944,7 @@ fewer IOThreads than CPU, each IOThread will be pinned to a set of CPUs.
 #### IOThreads with QEMU Emulator thread and Dedicated (pinned) CPUs
 
 To further improve the vCPUs latency, KubeVirt can allocate an
-additional dedicated physical CPU[1](virtual_machines/virtual_hardware/#cpu), exclusively for the emulator thread, to which it will
+additional dedicated physical CPU<sup>[1](../virtual_hardware#cpu)</sup>, exclusively for the emulator thread, to which it will
 be pinned. This will effectively "isolate" the emulator thread from the vCPUs
 of the VMI. When `ioThreadsPolicy` is set to `auto` IOThreads will also be
 "isolated" from the vCPUs and placed on the same physical CPU as the QEMU

--- a/docs/virtual_machines/disks_and_volumes.md
+++ b/docs/virtual_machines/disks_and_volumes.md
@@ -944,7 +944,7 @@ fewer IOThreads than CPU, each IOThread will be pinned to a set of CPUs.
 #### IOThreads with QEMU Emulator thread and Dedicated (pinned) CPUs
 
 To further improve the vCPUs latency, KubeVirt can allocate an
-additional dedicated physical CPU[1](creation/dedicated-cpu.md), exclusively for the emulator thread, to which it will
+additional dedicated physical CPU[1](virtual_machines/virtual_hardware/#cpu), exclusively for the emulator thread, to which it will
 be pinned. This will effectively "isolate" the emulator thread from the vCPUs
 of the VMI. When `ioThreadsPolicy` is set to `auto` IOThreads will also be
 "isolated" from the vCPUs and placed on the same physical CPU as the QEMU

--- a/docs/virtual_machines/guest_operating_system_information.md
+++ b/docs/virtual_machines/guest_operating_system_information.md
@@ -155,7 +155,7 @@ Once the `VirtualMachineInstancePreset` is applied to the
           persistentVolumeClaim:
             claimName: my-windows-image
 
-For more information see [VirtualMachineInstancePresets](presets.md)
+For more information see [VirtualMachineInstancePresets](../presets)
 
 ### HyperV optimizations
 

--- a/docs/virtual_machines/guest_operating_system_information.md
+++ b/docs/virtual_machines/guest_operating_system_information.md
@@ -35,7 +35,7 @@ are currently supported:
 <td><p>Microsoft Windows Server 2012 R2</p></td>
 <td><p>6.3</p></td>
 <td><p>winnt</p></td>
-<td><p><a href="http://microsoft.com/win/2k12r2">http://microsoft.com/win/2k12r2</a></p></td>
+<td><p><a href="https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2012-r2">https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2012-r2</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/docs/virtual_machines/replicaset.md
+++ b/docs/virtual_machines/replicaset.md
@@ -65,7 +65,7 @@ Using VirtualMachineInstanceReplicaSet is the right choice when one
 wants many identical VMs and does not care about maintaining any disk
 state after the VMs are terminated.
 
-[Volume types](disks_and_volumes.md) which
+[Volume types](../disks_and_volumes) which
 work well in combination with a VirtualMachineInstanceReplicaSet are:
 
 -   **cloudInitNoCloud**

--- a/docs/virtual_machines/replicaset.md
+++ b/docs/virtual_machines/replicaset.md
@@ -65,7 +65,7 @@ Using VirtualMachineInstanceReplicaSet is the right choice when one
 wants many identical VMs and does not care about maintaining any disk
 state after the VMs are terminated.
 
-[Volume types](workloads/virtual-machines/disks-and-volumes.md) which
+[Volume types](disks_and_volumes.md) which
 work well in combination with a VirtualMachineInstanceReplicaSet are:
 
 -   **cloudInitNoCloud**

--- a/docs/virtual_machines/service_objects.md
+++ b/docs/virtual_machines/service_objects.md
@@ -1,4 +1,4 @@
-# Service object
+# Service objects
 
 Once the VirtualMachineInstance is started, in order to connect to a
 VirtualMachineInstance, you can create a `Service` object for a

--- a/docs/virtual_machines/startup_scripts.md
+++ b/docs/virtual_machines/startup_scripts.md
@@ -243,8 +243,7 @@ More cloud-config examples can be found here: [Cloud-init
 Examples](https://cloudinit.readthedocs.io/en/latest/topics/examples.html)
 
 Below is an example of using cloud-config to inject an SSH key for the
-default user (fedora in this case) of a [Fedora
-Atomic](https://getfedora.org/en/atomic/download/) disk image.
+default user (fedora in this case) of a [Fedora Atomic](https://www.projectatomic.io/) disk image.
 
     # Create the cloud-init cloud-config userdata.
     cat << END > startup-script

--- a/docs/virtual_machines/templates.md
+++ b/docs/virtual_machines/templates.md
@@ -6,7 +6,7 @@ KubeVirt on OpenShift).
 
 By deploying KubeVirt on top of OpenShift the user can benefit from the
 [OpenShift
-Template](https://docs.openshift.org/latest/dev_guide/templates.html)
+Template](https://docs.openshift.com/container-platform/4.6/virt/vm_templates/virt-creating-vm-template.html)
 functionality.
 
 ## Virtual machine templates
@@ -14,7 +14,7 @@ functionality.
 ### What is a virtual machine template?
 
 The KubeVirt projects provides a set of
-[templates](https://docs.okd.io/latest/dev_guide/templates.html) to
+[templates](https://docs.okd.io/latest/openshift_images/using-templates.html) to
 create VMs to handle common usage scenarios. These templates provide a
 combination of some key factors that could be further customized and
 processed to have a Virtual Machine object. The key factors which define
@@ -93,9 +93,7 @@ the following minimal snippet highlights the fields which you can edit:
 
 ### Relationship between templates and VMs
 
-Once
-[processed](https://docs.openshift.com/enterprise/3.0/dev_guide/templates.html#creating-from-templates-using-the-cli),
-the templates produce VM objects to be used in the cluster. The VMs
+Once processed the templates produce VM objects to be used in the cluster. The VMs
 produced from templates will have a `vm.kubevirt.io/template` label,
 whose value will be the name of the parent template, for example
 `fedora-desktop-medium`:
@@ -178,7 +176,7 @@ vice versa).
 The templates provided by the kubevirt project provide a set of
 conventions and annotations that augment the basic feature of the
 [openshift
-templates](https://docs.okd.io/latest/dev_guide/templates.html). You can
+templates](https://docs.okd.io/latest/openshift_images/using-templates.html). You can
 customize your kubevirt-provided templates editing these annotations, or
 you can add them to your existing templates to make them consumable by
 the kubevirt services.
@@ -366,7 +364,7 @@ spec:
 ### Overview
 
 The KubeVirt projects provides a set of
-[templates](https://docs.okd.io/latest/dev_guide/templates.html) to
+[templates](https://github.com/kubevirt/kubevirt/tree/master/examples) to
 create VMs to handle common usage scenarios. These templates provide a
 combination of some key factors that could be further customized and
 processed to have a Virtual Machine object.
@@ -486,7 +484,7 @@ An OpenShift template has to be converted into the JSON file via
 parameters.
 
 A complete example can be found in the [KubeVirt
-repository](https://github.com/kubevirt/kubevirt/blob/master/cluster/examples/vm-template-fedora.yaml).
+repository](https://raw.githubusercontent.com/kubevirt/kubevirt/master/examples/vm-template-fedora.yaml).
 
 !> You need to be logged in by `oc login` command.
 

--- a/docs/virtual_machines/templates.md
+++ b/docs/virtual_machines/templates.md
@@ -672,4 +672,4 @@ path
 Available in the each OpenShift/Kubevirt compute nodes.
 
 ## Additional information
-You can follow [Virtual Machine Lifecycle Guide](lifecycle.md) for further reference.
+You can follow [Virtual Machine Lifecycle Guide](../lifecycle) for further reference.

--- a/docs/virtual_machines/templates.md
+++ b/docs/virtual_machines/templates.md
@@ -391,12 +391,7 @@ blue button >> choose "Create from wizard". Next, you have to see
 
 ### Common-templates
 
-There is the [common-templates
-subproject](https://github.com/kubevirt/common-templates/)
-subproject. It provides official prepared and useful templates.
-[Additional doc available](templates/common-templates.md).
-You can also create templates by hand. You can find an example below, in
-the "Example template" section.
+There is the [common-templates](https://github.com/kubevirt/common-templates/) subproject. It provides official prepared and useful templates. You can also create templates by hand. You can find an example below, in the "Example template" section.
 
 ### Example template
 
@@ -679,4 +674,4 @@ path
 Available in the each OpenShift/Kubevirt compute nodes.
 
 ## Additional information
-You can follow [Virtual Machine Lifecycle Guide](usage/life-cycle.md) for further reference.
+You can follow [Virtual Machine Lifecycle Guide](lifecycle.md) for further reference.

--- a/docs/virtual_machines/virtual_machine_instances.md
+++ b/docs/virtual_machines/virtual_machine_instances.md
@@ -67,10 +67,10 @@ require a provisioner in your cluster.
 ## Additional Information
 
 -   More information about persistent and ephemeral volumes:
-    [Disks and Volumes](creation/disks-and-volumes.md)
+    [Disks and Volumes](disks_and_volumes.md)
 
 -   How to access a VirtualMachineInstance via `console` or `vnc`:
-    [Console Access](usage/graphical-and-console-access.md)
+    [Console Access](graphical_and_console_access.md)
 
 -   How to customize VirtualMachineInstances with `cloud-init`:
-    [Cloud Init](creation/cloud-init.md)
+    [Cloud Init](startup_scripts#cloud-init)

--- a/docs/virtual_machines/virtual_machine_instances.md
+++ b/docs/virtual_machines/virtual_machine_instances.md
@@ -67,10 +67,10 @@ require a provisioner in your cluster.
 ## Additional Information
 
 -   More information about persistent and ephemeral volumes:
-    [Disks and Volumes](disks_and_volumes.md)
+    [Disks and Volumes](../disks_and_volumes)
 
 -   How to access a VirtualMachineInstance via `console` or `vnc`:
-    [Console Access](graphical_and_console_access.md)
+    [Console Access](../graphical_and_console_access)
 
 -   How to customize VirtualMachineInstances with `cloud-init`:
-    [Cloud Init](startup_scripts#cloud-init)
+    [Cloud Init](../startup_scripts#cloud-init)

--- a/docs/virtual_machines/windows_virtio_drivers.md
+++ b/docs/virtual_machines/windows_virtio_drivers.md
@@ -20,34 +20,34 @@ There are usually up to 8 possible devices that are required to run
 Windows smoothly in a virtualized environment. KubeVirt currently
 supports only:
 
--   **viostor**, the block driver, applies to SCSI Controller in the
+- **viostor**, the block driver, applies to SCSI Controller in the
     Other devices group.
 
--   **viorng**, the entropy source driver, applies to PCI Device in the
+- **viorng**, the entropy source driver, applies to PCI Device in the
     Other devices group.
 
--   **NetKVM**, the network driver, applies to Ethernet Controller in
+- **NetKVM**, the network driver, applies to Ethernet Controller in
     the Other devices group. Available only if a virtio NIC is
     configured.
 
 Other virtio drivers, that exists and might be supported in the future:
 
--   Balloon, the balloon driver, applies to PCI Device in the Other
+- Balloon, the balloon driver, applies to PCI Device in the Other
     devices group
 
--   vioserial, the paravirtual serial driver, applies to PCI Simple
+- vioserial, the paravirtual serial driver, applies to PCI Simple
     Communications Controller in the Other devices group.
 
--   vioscsi, the SCSI block driver, applies to SCSI Controller in the
+- vioscsi, the SCSI block driver, applies to SCSI Controller in the
     Other devices group.
 
--   qemupciserial, the emulated PCI serial driver, applies to PCI Serial
+- qemupciserial, the emulated PCI serial driver, applies to PCI Serial
     Port in the Other devices group.
 
--   qxl, the paravirtual video driver, applied to Microsoft Basic
+- qxl, the paravirtual video driver, applied to Microsoft Basic
     Display Adapter in the Display adapters group.
 
--   pvpanic, the paravirtual panic driver, applies to Unknown device in
+- pvpanic, the paravirtual panic driver, applies to Unknown device in
     the Other devices group.
 
 > **Note**
@@ -106,7 +106,7 @@ Enterprise Linux 7](https://access.redhat.com/articles/2470791).
 ## How to obtain virtio drivers?
 
 The virtio Windows drivers are distributed in a form of
-[containerDisk](https://kubevirt.io/user-guide/docs/latest/creating-virtual-machines/disks-and-volumes.html#containerDisk),
+[containerDisk](../disks_and_volumes/#containerdisk),
 which can be simply mounted to the VirtualMachine. The container image,
 containing the disk is located at:
 <https://hub.docker.com/r/kubevirt/virtio-container-disk> and the image

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -17,7 +17,7 @@ This page is provided as the entrypoint to the different topics of this user-gui
 
 ## Developer
 
-- Start contributing: [Appendix/Contributing](appendix/contributing.md)
+- Start contributing: [Appendix/Contributing](appendix/contributing)
 
 - API Reference: <http://kubevirt.io/api-reference/>
 

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -5,25 +5,25 @@ This page is provided as the entrypoint to the different topics of this user-gui
 
 ## Try it out
 
--   An easy to use demo: <https://github.com/kubevirt/demo>
+- An easy to use demo: <https://github.com/kubevirt/demo>
 
 ## Getting help
 
--   File a bug: <https://github.com/kubevirt/kubevirt/issues>
+- File a bug: <https://github.com/kubevirt/kubevirt/issues>
 
--   Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
 
--   Slack: <https://kubernetes.slack.com/messages/virtualization>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
 
 ## Developer
 
--   Start contributing: [Appendix/Contributing](appendix/contributing.md)
+- Start contributing: [Appendix/Contributing](appendix/contributing.md)
 
--   API Reference: <http://kubevirt.io/api-reference/>
+- API Reference: <http://kubevirt.io/api-reference/>
 
 ## Privacy
 
--   Check our privacy policy at: <https://kubevirt.io/privacy/>
+- Check our privacy policy at: <https://kubevirt.io/privacy/>
 
--   We do use <https://netlify.com> Open Source Plan for Rendering Pull
-    Requests to the documentation repository
+- We do use <https://netlify.com> Open Source Plan for Rendering Pull
+  Requests to the documentation repository

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: KubeVirt User-Guide
-site_url: https://kubevirt.io/docs
+site_url: https://kubevirt.io/user-guide
 site_description: Documentation for KubeVirt
 docs_dir: docs
 site_dir: site


### PR DESCRIPTION
Fix failing links in content.  mkdocs build is now clean.

```
# make run
make: Warning: File 'Makefile' has modification time 0.59 s in the future

Makefile: Stop site
podman rm -f userguide 2> /dev/null; echo

Makefile: Run site
podman run -d --name userguide --net=host -v ./:/srv:ro --mount type=tmpfs,destination=/srv/site localhost/kubevirt-userguide:latest /bin/bash -c "mkdocs build -f /srv/mkdocs.yml && mkdocs serve -f /srv/mkdocs.yml -a 0.0.0.0:8000"
66c82bbb1529e19f49dd80eac6603f7ceefcdee955e7859b39e9f9f819fd6105

[root@fedora user-guide]# podman logs -f userguide
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /srv/site
INFO    -  Documentation built in 1.22 seconds
INFO    -  Building documentation...
WARNING -  Config value: 'dev_addr'. Warning: The use of the IP address '0.0.0.0' suggests a production environment or the use of a proxy to connect to the MkDocs server. However, the MkDocs' server is intended for local development purposes only. Please use a third party production-ready server instead.
INFO    -  Cleaning site directory
INFO    -  Documentation built in 1.15 seconds
[I 210218 03:02:30 server:335] Serving on http://0.0.0.0:8000
INFO    -  Serving on http://0.0.0.0:8000
[I 210218 03:02:30 handlers:62] Start watching changes
INFO    -  Start watching changes
[I 210218 03:02:30 handlers:64] Start detecting changes
INFO    -  Start detecting changes
[I 210218 03:02:45 handlers:135] Browser Connected: http://0.0.0.0:8003/virtual_machines/service_objects/
INFO    -  Browser Connected: http://0.0.0.0:8003/virtual_machines/service_objects/
```

Fixed the following...
* Ooof, mkdocs site_url config didn't get changed to `/user-guide` that caused 100s internal links to fail
* windows_virtio_driver page was misspelled, really?
* handful of  link fixes that we normally do
* handful of content fixes related to broken links