### PR TITLE
host devices: case consistency

### DIFF
--- a/docs/virtual_machines/host-devices.md
+++ b/docs/virtual_machines/host-devices.md
@@ -69,7 +69,7 @@ configuration:
       resourceName: "nvidia.com/TU104GL_Tesla_T4"
       externalResourceProvider: true
     - pciVendorSelector: "8086:6F54"
-      resourceName: "intel.com/QAT"
+      resourceName: "intel.com/qat"
     mediatedDevices:
     - mdevNameSelector: "GRID T4-1Q"
       resourceName: "nvidia.com/GRID_T4-1Q"


### PR DESCRIPTION
I suspect that the host device name in the VM spec must match the one
exposed by KubeVirt device plugin.

Please do not merge before approval by @vladikr.