### PR TITLE
fix cdi cr download broken link

### DIFF
--- a/docs/operations/containerized_data_importer.md
+++ b/docs/operations/containerized_data_importer.md
@@ -23,7 +23,7 @@ Install the latest CDI release
 
     VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
     kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml
-    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator-cr.yaml
+    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-cr.yaml
 
 ## Expose cdi-uploadproxy service
 


### PR DESCRIPTION
Fix cdi cr yaml file broken download link according to [release page](https://github.com/kubevirt/containerized-data-importer/releases). 

Signed-off-by: clarkzjw <clarkzjw@gmail.com>