### PR TITLE
Fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Targets:
 
 * build_image_userguide: mkdocs project does not provide a container image.  Use this target to build an image packed with python and mkdocs app.  ./docs will be mounted.  ./site will be mounted as tmpfs...changes here are lost.
 
-* build_image_yaspeller: yaspeller project does not provide a container image.  User this target to Build an image packed with nodejs and yaspeller app.  ./docs will be mounted.  yasspeller will check content for spelling and other bad forms of English.
+* build_image_yaspeller: yaspeller project does not provide a container image.  User this target to Build an image packed with nodejs and yaspeller app.  ./docs will be mounted.  yaspeller will check content for spelling and other bad forms of English.
 
 * status: Basically `${BUILD_ENGINE} ps` for an easy way to see what's running.
 


### PR DESCRIPTION
Quick spelling fix

```console
$ make check_spelling

Makefile: Stop site
podman rm -f userguide 2> /dev/null; echo

Makefile: Check spelling on site content
Using local dictionary file
Dictionary file: yaspeller.json
Be sure to add changes to upstream: kubevirt/project-infra/master/images/yaspeller/.yaspeller.json

Spelling check:
Complete!
```