### PR TITLE
Fix to Gemfile.lock read-only warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ check_links: | envvar stop
 				--rm \
 				--name userguide \
 				-v ${PWD}:/srv:ro${SELINUX_ENABLED} \
+				-v /dev/null:/srv/Gemfile.lock \
 				--mount type=tmpfs,destination=/srv/site \
 				kubevirt-userguide \
 				/bin/bash -c 'cd /srv; bundle install --quiet; rake -- -u'


### PR DESCRIPTION
HTMLProofer throws a warning regarding Gemfile.lock being read-only.  This file causes neverending issues so we volume mount `/dev/null` to the file.

I thought I fixed this before but it somehow slipped out.  So here is the patch again.