### PR TITLE
[FIX] Update virtctl_client_tool.md

### DIFF
--- a/docs/operations/virtctl_client_tool.md
+++ b/docs/operations/virtctl_client_tool.md
@@ -28,8 +28,8 @@ There are two ways to get it:
 Example:
 
 ```
-export VERSION=v0.26.1
-wget https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/virtctl-${VERSION}-linux-x86_64
+export VERSION=v0.41.0
+wget https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/virtctl-${VERSION}-linux-amd64
 ```
 
 ## Install `virtctl` with `krew`


### PR DESCRIPTION
Updated URL and version to latest, to download the virtctl linux client for 64-bit x86 processors. The current text references to the `linux-x86_64` os-arch pair, but the latest version [v0.41.0](https://github.com/kubevirt/kubevirt/releases/tag/v0.41.0) references it with [linux-amd64](https://github.com/kubevirt/kubevirt/releases/download/v0.41.0/virtctl-v0.41.0-linux-amd64).

```
$>export VERSION=v0.41.0
$> wget https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/virtctl-${VERSION}-linux-x86_64
--2021-05-21 21:02:38--  https://github.com/kubevirt/kubevirt/releases/download/v0.41.0/virtctl-v0.41.0-linux-x86_64
Resolving github.com (github.com)... 140.82.112.4
Connecting to github.com (github.com)|140.82.112.4|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2021-05-21 21:02:38 ERROR 404: Not Found.
```