### PR TITLE
Document live-migration reserved ports

### DIFF
--- a/docs/operations/live_migration.md
+++ b/docs/operations/live_migration.md
@@ -19,6 +19,9 @@ field in the KubeVirt CR must be expanded by adding the `LiveMigration` to it.
   interface type
   (</#/creation/interfaces-and-networks>)
 
+- Live migration requires ports `22222, 49152, 49153` to be available in the virt-launcher pod.
+  If these ports are explicitly specified in [masquarade interface](</#/virtual_machines/interfaces_and_networks/#masquerade>), live migration will not function.
+
 ## Initiate live migration
 
 Live migration is initiated by posting a VirtualMachineInstanceMigration


### PR DESCRIPTION
When using VMI masquarade interface withany of the explicitly
specified ports 22222, 49152, 49153, live migration fails, because
all traffic destined to the said ports is forwarded
to the VM.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>