### PR TITLE
Fix: fix path in architecture.md from absolute path to related

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,11 +67,11 @@ users to speak to Kubernetes, but modify VMIs.
 The following diagram illustrates how the additional controllers and daemons
 communicate with Kubernetes and where the additional types are stored:
 
-![Architecture diagram](/docs/assets/architecture.png "Architecture")
+![Architecture diagram](assets/architecture.png "Architecture")
 
 And a simplified version:
 
-![Simplified architecture diagram](/docs/assets/architecture-simple.png "Simplified architecture")
+![Simplified architecture diagram](assets/architecture-simple.png "Simplified architecture")
 
 ## Application Layout
 


### PR DESCRIPTION
Image path is incorrect with starting slash
follow other page to fix it and remove the starting slash to be related path and be migratable again.

Signed-off-by: Date Huang <tjjh89017@hotmail.com>