### PR TITLE
live-migration: port 22222 is no longer used by virt-launcher

### DIFF
--- a/docs/operations/live_migration.md
+++ b/docs/operations/live_migration.md
@@ -19,7 +19,7 @@ field in the KubeVirt CR must be expanded by adding the `LiveMigration` to it.
   interface type
   (</#/creation/interfaces-and-networks>)
 
-- Live migration requires ports `22222, 49152, 49153` to be available in the virt-launcher pod.
+- Live migration requires ports `49152, 49153` to be available in the virt-launcher pod.
   If these ports are explicitly specified in [masquarade interface](</#/virtual_machines/interfaces_and_networks/#masquerade>), live migration will not function.
 
 ## Initiate live migration


### PR DESCRIPTION
As of commit 97caf4ea7.

Signed-off-by: Antonio Cardace <acardace@redhat.com>