### PR TITLE
Updated the Try it Out! bullet point

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,13 @@ This page is provided as the entrypoint to the different topics of this user-gui
 
 ## Try it out
 
-- An easy to use demo: <https://github.com/kubevirt/demo>
+- Kubevirt on katacoda: <https://www.katacoda.com/kubevirt>
+
+- Kubevirt on minikube: <https://kubevirt.io/quickstart_minikube/>
+
+- Kubevirt on kind: <https://kubevirt.io/quickstart_kind/>
+
+- Kubevirt on cloud providers: <https://kubevirt.io/quickstart_cloud/>
 
 ## Getting help
 


### PR DESCRIPTION
Removing https://github.com/kubevirt/demo and added links for 

- Katacoda scenarios as it  provides an live interactive demo.
- Quickstart labs as they are updated on a regular basis.

Fixes https://github.com/kubevirt/user-guide/issues/482
Signed-off-by: ansijain <ansi.jain@india.nec.com>