### PR TITLE
bugfix sysprep doc

### DIFF
--- a/docs/virtual_machines/startup_scripts.md
+++ b/docs/virtual_machines/startup_scripts.md
@@ -1091,7 +1091,7 @@ spec:
             name: win10-iso
           name: windows-iso
         - dataVolume:
-            name: win10-template
+            name: win10-template-windows-iso
           name: win10-template
         - containerDisk:
             image: kubevirt/virtio-container-disk


### PR DESCRIPTION
naming mismatch between data volume template and volume spec in vm manifest.
https://kubernetes.slack.com/archives/C8ED7RKFE/p1633450358199300

Signed-off-by: jay <jayasai470@gmail.com>