### PR TITLE
Fix doc for batchEviction{Size,Interval}

### DIFF
--- a/docs/operations/updating_and_deletion.md
+++ b/docs/operations/updating_and_deletion.md
@@ -108,8 +108,8 @@ spec:
   workloadUpdateStrategy:
     workloadUpdateMethods:
       - Evict
-    batchEvictSize: 10
-    batchEvictInterval: "1m"
+    batchEvictionSize: 10
+    batchEvictionInterval: "1m"
 ```
 
 
@@ -132,8 +132,8 @@ spec:
     workloadUpdateMethods:
       - LiveMigrate
       - Evict
-    batchEvictSize: 10
-    batchEvictInterval: "1m"
+    batchEvictionSize: 10
+    batchEvictionInterval: "1m"
 ```
 
 ## Deleting KubeVirt


### PR DESCRIPTION
Documentation examples showed batchEvict{Size,Interval} instead of batchEviction{Size,Interval}.