### PR TITLE
add limitations when memfd is supported

### DIFF
--- a/docs/virtual_machines/virtual_hardware.md
+++ b/docs/virtual_machines/virtual_hardware.md
@@ -605,6 +605,8 @@ regular memory it will use node hugepages of the size of `2Mi`.
 
 -   requested memory must be divisible by hugepages size
 
+-   hugepages uses by default memfd. Memfd is supported from kernel >= 4.14. If you run on an older host (e.g centos 7.9), it is required to disable memfd with the annotation `kubevirt.io/memfd: "false"` in the VMI metadata annotation.
+
 ## Input Devices
 
 ### Tablet


### PR DESCRIPTION
A couple of users asked about the support for memfd because they got the error `unsupported configuration: hugepages is not supported with memfd memory source`. This limitation is due to a too old host kernel. Adding this information could be useful to prevent other doubts.
