### PR TITLE
docs, network: clarify MAC setting on pod iface requires multus

### DIFF
--- a/docs/virtual_machines/interfaces_and_networks.md
+++ b/docs/virtual_machines/interfaces_and_networks.md
@@ -286,10 +286,10 @@ spec:
     pod: {}
 ```
 
-> **Note:** If a specific MAC address is configured for a virtual
-> machine interface, it's passed to the underlying CNI plugin that is
-> expected to configure the backend to allow for this particular MAC
-> address. Not every plugin has native support for custom MAC addresses.
+> **Note:** For secondary interfaces, when a MAC address is specified for a
+> virtual machine interface, it is passed to the underlying CNI plugin which is,
+> in turn, expected to configure the backend to allow for this particular MAC.
+> Not every plugin has native support for custom MAC addresses.
 
 > **Note:** For some CNI plugins without native support for custom MAC
 > addresses, there is a workaround, which is to use the `tuning` CNI


### PR DESCRIPTION
The MAC address of the VMI is only propagated to the underlying CNI
for multus non default networks.

Fixes: https://github.com/kubevirt/kubevirt/issues/7055

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>