### PR TITLE
network, macvtap: fix markdown

### DIFF
--- a/docs/virtual_machines/interfaces_and_networks.md
+++ b/docs/virtual_machines/interfaces_and_networks.md
@@ -785,9 +785,10 @@ The aforementioned operator effectively deploys the
 combo.
 
 There are two different alternatives to configure which host interfaces get
-exposed to the user, enabling them to create macvtap interfaces on top of;
-  - select the host interfaces: indicates which host interfaces are exposed.
-  - expose all interfaces: all interfaces of all hosts are exposed.
+exposed to the user, enabling them to create macvtap interfaces on top of:
+
+- select the host interfaces: indicates which host interfaces are exposed.
+- expose all interfaces: all interfaces of all hosts are exposed.
 
 Both options are configured via the `macvtap-deviceplugin-config` ConfigMap,
 and more information on how to configure it can be found in the


### PR DESCRIPTION
The text is currently not rendered correctly on the [0] web, since the
list entries are featuring extra spaces.

[0] - https://kubevirt.io/user-guide/virtual_machines/interfaces_and_networks/#how-to-expose-host-interface-to-the-macvtap-device-plugin

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>