### PR TITLE
docs, network: document bridge interface invalid CNIs

### DIFF
--- a/docs/virtual_machines/interfaces_and_networks.md
+++ b/docs/virtual_machines/interfaces_and_networks.md
@@ -181,6 +181,23 @@ spec:
       networkName: macvlan-test
 ```
 
+#### Invalid CNIs for secondary networks
+The following list of CNIs is known **not** to work for bridge interfaces -
+which are most common for secondary interfaces.
+- [macvlan](https://www.cni.dev/plugins/current/main/macvlan/)
+- [ipvlan](https://www.cni.dev/plugins/current/main/ipvlan/)
+
+The reason is similar: the bridge interface type moves the pod interface MAC
+address to the VM, leaving the pod interface with a different address. The
+aforementioned CNIs require the pod interface to have the original MAC address.
+
+These issues are tracked individually:
+- [macvlan](https://github.com/kubevirt/kubevirt/issues/5483)
+- [ipvlan](https://github.com/kubevirt/kubevirt/issues/7001)
+
+Feel free to discuss and / or propose fixes for them; we'd like to have
+these plugins as valid options on our ecosystem.
+
 ## Frontend
 
 Network interfaces are configured in `spec.domain.devices.interfaces`.


### PR DESCRIPTION
There are recurring issues being created on KubeVirt related to some CNIs being used which we know do not work with our bridge binding option - the most common choice for secondary interfaces. 

Example issues: [[0](https://github.com/kubevirt/kubevirt/issues/5483)], [[1](https://github.com/kubevirt/kubevirt/issues/7001)], but there are more ...

For instance, we know that neither macvlan nor ipvlan plugins will work when the plugin configuration features IPAM for secondary bridge interfaces.

This commit adds a section to the user guide describing which plugins are known not work, along with a brief explanation of why.

