### PR TITLE
Fix example in kubevirtCR to set obsoleteCPUModels with correct values

### DIFF
--- a/docs/virtual_machines/virtual_hardware.md
+++ b/docs/virtual_machines/virtual_hardware.md
@@ -157,8 +157,8 @@ cpu model for features. Both features can be set via KubeVirt CR:
       configuration:
         minCPUModel: "Penryn"
         obsoleteCPUModels:
-          - "486"
-          - "pentium"
+          486: true
+          pentium: true
     ...
 ```
 


### PR DESCRIPTION
Fix example in kubevirtCR to set obsoleteCPUModels with correct values.
https://kubevirt.io/api-reference/master/definitions.html#_v1_kubevirtconfiguration

