### PR TITLE
Certificate for virtctl image-upload can be used without update-ca-trust

### DIFF
--- a/docs/operations/containerized_data_importer.md
+++ b/docs/operations/containerized_data_importer.md
@@ -198,9 +198,7 @@ Download the cdi-uploadproxy-server-cert.
 
 Add this certificate to the systems trust store. On Fedora, this can be done as follows.
 
-    sudo cp cdi-uploadproxy-server-cert.crt /etc/pki/ca-trust/source/anchors
-
-    sudo update-ca-trust
+    sudo cp cdi-uploadproxy-server-cert.crt /etc/pki/tls/certs
 
 The upload should now work.
 


### PR DESCRIPTION
For Fedora/RHEL:
When you add a certificate to "/etc/pki/tls/certs", you don't need to run 'sudo update-ca-trust'.