### PR TITLE
Adjust on the get of the latest CDI tag version

### DIFF
--- a/docs/operations/containerized_data_importer.md
+++ b/docs/operations/containerized_data_importer.md
@@ -21,7 +21,8 @@ virtctl in your path.
 Install the latest CDI release
 [here](https://github.com/kubevirt/containerized-data-importer/releases)
 
-    VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+    export TAG=$(curl -s -w %{redirect_url} https://github.com/kubevirt/containerized-data-importer/releases/latest)
+    export VERSION=$(echo ${TAG##*/})
     kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml
     kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-cr.yaml
 


### PR DESCRIPTION
The current curl don't get the latest CDI version. The proposal is to read the "location" that curl receives in the 302 return of the request, and parses to get the tag in the URL.

Signed-off-by: Rafael Domiciano <rafael.domiciano@gmail.com>