### PR TITLE
add delete virt-operator-validator webhook guide

### DIFF
--- a/docs/operations/updating_and_deletion.md
+++ b/docs/operations/updating_and_deletion.md
@@ -145,6 +145,7 @@ resource and then delete the KubeVirt operator.
     $ kubectl delete -n kubevirt kubevirt kubevirt --wait=true # --wait=true should anyway be default
     $ kubectl delete apiservices v1alpha3.subresources.kubevirt.io # this needs to be deleted to avoid stuck terminating namespaces
     $ kubectl delete mutatingwebhookconfigurations virt-api-mutator # not blocking but would be left over
+    $ kubectl delete validatingwebhookconfigurations virt-operator-validator # not blocking but would be left over
     $ kubectl delete validatingwebhookconfigurations virt-api-validator # not blocking but would be left over
     $ kubectl delete -f https://github.com/kubevirt/kubevirt/releases/download/${RELEASE}/kubevirt-operator.yaml --wait=false
 


### PR DESCRIPTION
# Fix issue https://github.com/kubevirt/kubevirt/issues/8131
By add delete `kubectl delete validatingwebhookconfigurations virt-operator-validator` to docs/operations/updating_and_deletion.md

