### PR TITLE
Renaming 'Latest release notes' to 'KubeVirt release notes'

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -1,7 +1,7 @@
 nav:
   - Welcome: index.md
   - architecture.md
-  - latest_release_notes.md
+  - release_notes.md
   - operations
   - virtual_machines
   - web_console.md

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,4 +1,4 @@
-# Latest release notes
+# KubeVirt release notes
 
 ## v0.55.0
 

--- a/update_changelog.sh
+++ b/update_changelog.sh
@@ -21,14 +21,14 @@ features_for() {
 
 gen_changelog() {
   IFS=$'\n'
-  sed -i -e "s/# Latest release notes//" ./docs/latest_release_notes.md
+  sed -i -e "s/# KubeVirt release notes//" ./docs/release_notes.md
   REL_NOTES=$(for REL in `releases $1`; do
     echo -e "## $REL\n" ;
     features_for $REL
   done)
-  printf '%s %s\n' "$REL_NOTES `cat docs/latest_release_notes.md`" > ./docs/latest_release_notes.md
-  sed -i "1 i\# Latest release notes\n" ./docs/latest_release_notes.md
-  sed -i 's/[ \t]*$//' docs/latest_release_notes.md
+  printf '%s %s\n' "$REL_NOTES `cat docs/release_notes.md`" > ./docs/release_notes.md
+  sed -i "1 i\# KubeVirt release notes\n" ./docs/release_notes.md
+  sed -i 's/[ \t]*$//' docs/release_notes.md
 }
 
 gen_changelog $1


### PR DESCRIPTION
Renaming 'Latest release notes' to KubeVirt release notes' in all relevant files. Also renames the release notes file (to drop 'latest_').

This is for #547. 
Github search showed that the files listed in that issue are the only ones in the project that refer to 'latest_release_notes.md'. The only point I'm not entirely sure about is the redirects. @cwilkers, do you know about redirects for kubevirt.io?

Signed-off-by: aburdenthehand <aburden@redhat.com>