### PR TITLE
Fix CDI version pulling

### DIFF
--- a/docs/operations/containerized_data_importer.md
+++ b/docs/operations/containerized_data_importer.md
@@ -21,7 +21,7 @@ virtctl in your path.
 Install the latest CDI release
 [here](https://github.com/kubevirt/containerized-data-importer/releases)
 
-    VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+    VERSION=$(curl -sL https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -m1 -o "v[0-9]\.[0-9]*\.[0-9]*")
     kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml
     kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-cr.yaml
 


### PR DESCRIPTION
The cURL invocation did not follow the redirect yielding no version. Added -L to follow links. Also added '-m1' to grep so only the first match is used instead of a long string like "v1.53.0 v1.53.0 v1.53.0 v1.52.0 v1.53.0 v1.52.0 v1.53.0..."