### PR TITLE
Mark VirtualMachineInstancePresets as deprecated

### DIFF
--- a/docs/virtual_machines/presets.md
+++ b/docs/virtual_machines/presets.md
@@ -1,5 +1,10 @@
 # Presets
 
+**FEATURE STATE:** 
+
+* `VirtualMachineInstancePresets` are deprecated as of the [`v0.57.0`](https://github.com/kubevirt/kubevirt/releases/tag/v0.57.0) release and will be removed in a future release. 
+* Users should instead look to use [Instancetypes and preferences](./instancetypes.md) as a replacement.
+
 `VirtualMachineInstancePresets` are an extension to general
 `VirtualMachineInstance` configuration behaving much like `PodPresets`
 from Kubernetes. When a `VirtualMachineInstance` is created, any


### PR DESCRIPTION
/area instancetype
/cc @akrejcir 

This CRD has now been deprecated within KubeVirt [1] and will be removed
in a future release once the core API reaches v2 [2].

[1] https://github.com/kubevirt/kubevirt/pull/8069
[2] https://github.com/kubevirt/kubevirt/issues/8360
