### PR TITLE
Fix list formatting in rendered docs (Application Layout)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,6 +94,7 @@ And a simplified version:
 VirtualMachineInstance (VMI) is the custom resource that represents the basic ephemeral building block of an instance.
 In a lot of cases this object won't be created directly by the user but by a high level resource.
 High level resources for VMI can be:
+
 * VirtualMachine (VM) - StateFul VM that can be stopped and started while keeping the VM data and state.
 * VirtualMachineInstanceReplicaSet (VMIRS) - Similar to pods ReplicaSet, a group of ephemeral VMIs with similar configuration defined in a template.
 


### PR DESCRIPTION
In the rendered docs this list is inlined because of a missing whitespace:
![image](https://user-images.githubusercontent.com/682686/189901562-a323fe86-5624-487d-9d37-a351a9e4bde9.png)
