### PR TITLE
Rework Accessing Virtual Machines section

### DIFF
--- a/docs/virtual_machines/accessing_virtual_machines.md
+++ b/docs/virtual_machines/accessing_virtual_machines.md
@@ -2,184 +2,135 @@
 
 ## Graphical and Serial Console Access
 
-Once a virtual machine is started you are able to connect to the
-consoles it exposes. Usually there are two types of consoles:
+Once a virtual machine is started you are able to connect to the consoles it
+exposes. Usually there are two types of consoles:
 
--   Serial Console
--   Graphical Console (VNC)
+- Serial Console
+- Graphical Console (VNC)
 
 > Note: You need to have `virtctl`
 > [installed](../operations/virtctl_client_tool.md) to gain
 > access to the VirtualMachineInstance.
 
+### Accessing the Serial Console
 
-### Accessing the serial console
+The serial console of a virtual machine can be accessed by using the `console`
+command:
 
-The serial console of a virtual machine can be accessed by using the
-`console` command:
+```shell
+virtctl console testvm
+```
 
-    $ virtctl console --kubeconfig=$KUBECONFIG testvmi
+### Accessing the Graphical Console (VNC)
 
+To access the graphical console of a virtual machine the VNC protocol is
+typically used. This requires `remote-viewer` to be installed. Once the
+tool is installed, you can access the graphical console using:
 
-### Accessing the graphical console (VNC)
+```shell
+virtctl vnc testvm
+```
 
-Accessing the graphical console of a virtual machine is usually done
-through VNC, which requires `remote-viewer`. Once the tool is installed
-you can access the graphical console using:
+If you only want to open a vnc-proxy without executing the `remote-viewer`
+command, it can be accomplished with:
 
-    $ virtctl vnc --kubeconfig=$KUBECONFIG testvmi
+```shell
+virtctl vnc --proxy-only testvm
+```
 
-If you need to open only a vnc-proxy without executing the `remote-viewer` command, it can be done using:
-
-    $ virtctl vnc --kubeconfig=$KUBECONFIG --proxy-only testvmi
-
-this would print the port number on your machine where you can manually connect using any of the vnc viewers
+This would print the port number on your machine where you can manually connect
+using any VNC viewer.
 
 ### Debugging console access
 
-Should the connection fail, you can use the `-v` flag to get more output
-from both `virtctl` and the `remote-viewer` tool, to troubleshoot the
+If the connection fails, you can use the `-v` flag to get more verbose
+output from both `virtctl` and the `remote-viewer` tool to troubleshoot the
 problem.
 
-    $ virtctl vnc --kubeconfig=$KUBECONFIG testvmi -v 4
+```shell
+virtctl vnc testvm -v 4
+```
 
-> **Note:** If you are using virtctl via ssh on a remote machine, you
-> need to forward the X session to your machine (Look up the -X and -Y
-> flags of `ssh` if you are not familiar with that). As an alternative
-> you can proxy the apiserver port with ssh to your machine (either
-> direct or in combination with `kubectl proxy`)
-
-
-### RBAC Permissions for Console/VNC Access
-
-#### Using Default RBAC ClusterRoles
-
-Every KubeVirt installation after version v0.5.1 comes a set of default
-RBAC cluster roles that can be used to grant users access to
-VirtualMachineInstances.
-
-The **kubevirt.io:admin** and **kubevirt.io:edit** ClusterRoles have
-console and VNC access permissions built into them. By binding either of
-these roles to a user, they will have the ability to use virtctl to
-access console and VNC.
-
-
-#### With Custom RBAC ClusterRole
-
-The default KubeVirt ClusterRoles give access to more than just console
-in VNC. In the event that an Admin would like to craft a custom role
-that targets only console and VNC, the ClusterRole below demonstrates
-how that can be done.
-
-    apiVersion: rbac.authorization.k8s.io/v1beta1
-    kind: ClusterRole
-    metadata:
-      name: allow-vnc-console-access
-    rules:
-      - apiGroups:
-          - subresources.kubevirt.io
-        resources:
-          - virtualmachineinstances/console
-          - virtualmachineinstances/vnc
-        verbs:
-          - get
-
-The ClusterRole above provides access to virtual machines across all
-namespaces.
-
-In order to reduce the scope to a single namespace, bind this
-ClusterRole using a RoleBinding that targets a single namespace.
+> **Note:** If you are using virtctl via SSH on a remote machine, you need to
+> forward the X session to your machine. Look up the -X and -Y flags of `ssh` if
+> you are not familiar with that. As an alternative you can proxy the API server
+> port with SSH to your machine (either direct or in combination
+> with `kubectl proxy`).
 
 ## SSH Access
 
 A common operational pattern used when managing virtual machines is to inject
-public ssh keys into the virtual machines at boot. This allows automation tools
-(like ansible) to provision the virtual machine. It also gives operators a way
-of gaining secure passwordless access to a virtual machine.
+SSH public keys into the virtual machines at boot. This allows automation tools
+(like Ansible) to provision the virtual machine. It also gives operators a way
+of gaining secure and passwordless access to a virtual machine.
 
-KubeVirt provides multiple ways to inject ssh public keys into a virtual
-machine. In general, these methods fall into two categories. [Static key injection](./accessing_virtual_machines.md#static-ssh-key-injection-via-cloud-init),
- which places keys on the virtual machine the first time it is
-booted, and [dynamic injection](./accessing_virtual_machines.md#dynamic-ssh-key-injection-via-qemu-user-agent), which allows keys to be dynamically updated
-both at boot and during runtime.
+KubeVirt provides multiple ways to inject SSH public keys into a virtual
+machine.
 
-### Static SSH Key Injection via Cloud Init
+In general, these methods fall into two categories:
+ - [Static key injection](./accessing_virtual_machines.md#static-ssh-key-injection-via-cloud-init),
+which places keys on the virtual machine the first time it is booted.
+ - [Dynamic key injection](./accessing_virtual_machines.md#dynamic-ssh-key-injection-via-qemu-user-agent),
+which allows keys to be dynamically updated both at boot and during runtime.
 
-Users creating virtual machines have the ability to provide startup scripts to
-their virtual machines which allow any number of custom operations to take place.
-Placing public ssh keys into a [cloud-init startup script](./startup_scripts.md#cloud-init) is one option people
-have for getting their public keys into the virtual machine, however there are
-some other options that grant more flexibility.
+Once a SSH public key is injected into the virtual machine, it can be
+accessed via `virtctl`.
 
-The VM's access credential api allows statically injecting ssh public keys at creation
-time independently of the cloud-init user data by placing the ssh public key
-in a Kubernetes secret. This is useful because it allows people creating virtual
-machines to separate the application data in their cloud-init user data from the
-credentials used to access the virtual machine.
+### Static SSH public key injection via cloud-init
 
-For example, someone can put their ssh key into a Kubernetes secret like this.
+Users creating virtual machines can provide startup scripts to their virtual
+machines, allowing multiple customization operations.
 
+One option for injecting public SSH keys into a VM is via
+[cloud-init startup script](./startup_scripts.md#cloud-init).
+However, there are more flexible options available.
+
+The virtual machine's access credential API allows statically injecting SSH
+public keys at startup time independently of the cloud-init user data by
+placing the SSH public key into a Kubernetes `Secret`. This allows keeping the
+application data in the cloud-init user data separate from the credentials
+used to access the virtual machine.
+
+A Kubernetes `Secret` can be created from an SSH public key like this:
+
+```shell
+# Place SSH public key into a Secret
+kubectl create secret generic my-pub-key --from-file=key1=id_rsa.pub
 ```
-# Place ssh key into a secret
 
-kubectl create secret generic my-pub-key --from-file=key1=/id_rsa.pub
-```
+The `Secret` containing the public key is then assigned to a virtual machine
+using the access credentials API with the `configDrive` propagation method.
 
-Then assign that key to the virtual machine with the access credentials api
-using the configDrive propagation method. Note here how the cloud-init user
-data is not touched. KubeVirt is injecting the ssh key into the virtual machine
-using the machine generated cloud-init metadata, and not the user data. This
-keeps the application user date separate from credentials.
+KubeVirt injects the SSH public key into the virtual machine by using the
+generated cloud-init metadata instead of the user data. This separates
+the application user data and user credentials.
 
+> Note: The cloud-init `userData` is not touched.
 
-```
-#Create a vm yaml that references the secret in using the access credentials api.
-
-
-cat << END > my-vm.yaml
+```shell
+# Create a VM referencing the Secret using propagation method configDrive
+kubectl create -f - <<EOF
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  labels:
-    kubevirt.io/vm: my-vm
-  name: my-vm
+  name: testvm
 spec:
-  dataVolumeTemplates:
-  - metadata:
-      creationTimestamp: null
-      name: fedora-dv
-    spec:
-      pvc:
-        accessModes:
-        - ReadWriteOnce
-        resources:
-          requests:
-            storage: 5Gi
-        storageClassName: local
-      source:
-        registry:
-          url: docker://quay.io/kubevirt/fedora-cloud-container-disk-demo
-  running: false
+  running: true
   template:
-    metadata:
-      labels:
-        kubevirt.io/vm: my-vm
     spec:
       domain:
         devices:
           disks:
           - disk:
               bus: virtio
-            name: disk0
+            name: containerdisk
           - disk:
               bus: virtio
-            name: disk1
-        machine:
-          type: ""
+            name: cloudinitdisk
+          rng: {}
         resources:
           requests:
-            cpu: 1000m
-            memory: 1G
+            memory: 1024M
       terminationGracePeriodSeconds: 0
       accessCredentials:
       - sshPublicKey:
@@ -189,98 +140,75 @@ spec:
           propagationMethod:
             configDrive: {}
       volumes:
-      - dataVolume:
-          name: fedora-dv
-        name: disk0
+      - containerDisk:
+          image: quay.io/containerdisks/fedora:latest
+        name: containerdisk
       - cloudInitConfigDrive:
-          userData: |
-            #!/bin/bash
-            echo "Application setup goes here"
-        name: disk1
-END
-
-kubectl create -f my-vm.yaml
-
+          userData: |-
+            #cloud-config
+            password: fedora
+            chpasswd: { expire: False }
+        name: cloudinitdisk
+EOF
 ```
 
-### Dynamic SSH Key Injection via Qemu User Agent
+### Dynamic SSH public key injection via qemu-guest-agent
 
-KubeVirt supports dynamically injecting public ssh keys at run time through the
-use of the qemu guest agent. This is achieved through the access credentials
-api by using the qemuGuestAgent propagation method.
+KubeVirt supports dynamic injection of SSH public keys at runtime by using
+the qemu-guest-agent. This is configured by using the access
+credentials API with the `qemuGuestAgent` propagation method.
 
-> Note: This requires the qemu guest agent to be installed within the guest
+> Note: This requires the qemu-guest-agent to be installed within the guest.
 >
-> Note: When using qemuGuestAgent propagation, the `/home/$USER/.ssh/authorized_keys`
-> file will be owned by the guest agent. Changes to that file that are made
-> outside of the qemu guest agent's control will get deleted.
+> Note: When using qemuGuestAgent propagation,
+> the `/home/$USER/.ssh/authorized_keys` file will be owned by the guest agent.
+> Changes to the file not made by the guest agent will be lost.
 >
-> Note: More information about the motivation behind the access credentials
-> api can be found in the [pull request description](https://github.com/kubevirt/kubevirt/pull/4195) that introduced this api.
+> Note: More information about the motivation behind the access credentials API
+> can be found in the
+> [pull request description](https://github.com/kubevirt/kubevirt/pull/4195)
+> that introduced the API.
 
-In the example below, a secret contains an ssh key. When attached to the
-VM via the access credential api with the qemuGuestAgent propagation method,
-the contents of the secret can be updated at any time which will automatically
-get applied to a running VM. The secret can contain multiple public keys.
+In the example below the `Secret` containing the SSH public key is
+attached to the virtual machine via the access credentials API with the
+`qemuGuestAgent` propagation method. This allows updating the contents of
+the `Secret` at any time, which will result in the changes getting applied
+to the running virtual machine immediately. The `Secret` may also contain
+multiple SSH public keys.
 
+```shell
+# Place SSH public key into a secret
+kubectl create secret generic my-pub-key --from-file=key1=id_rsa.pub
 ```
-# Place ssh key into a secret
 
-kubectl create secret generic my-pub-key --from-file=key1=/id_rsa.pub
-```
+Now reference this secret in the `VirtualMachine` spec with the access
+credentials API using
+`qemuGuestAgent` propagation.
 
-Now reference this secret on the VM with the access credentials api using
-qemuGuestAgent propagation. This example installs and starts the qemu guest
-agent using a cloud-init script in order to ensure the agent is available.
-
-```
-# Create a vm yaml that references the secret in using the access credentials api.
-
-
-cat << END > my-vm.yaml
+```shell
+# Create a VM referencing the Secret using propagation method qemuGuestAgent
+kubectl create -f - <<EOF
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  labels:
-    kubevirt.io/vm: my-vm
-  name: my-vm
+  name: testvm
 spec:
-  dataVolumeTemplates:
-  - metadata:
-      creationTimestamp: null
-      name: fedora-dv
-    spec:
-      pvc:
-        accessModes:
-        - ReadWriteOnce
-        resources:
-          requests:
-            storage: 5Gi
-        storageClassName: local
-      source:
-        registry:
-          url: docker://quay.io/kubevirt/fedora-cloud-container-disk-demo
-  running: false
+  running: true
   template:
-    metadata:
-      labels:
-        kubevirt.io/vm: my-vm
     spec:
       domain:
         devices:
           disks:
           - disk:
               bus: virtio
-            name: disk0
+            name: containerdisk
           - disk:
               bus: virtio
-            name: disk1
-        machine:
-          type: ""
+            name: cloudinitdisk
+          rng: {}
         resources:
           requests:
-            cpu: 1000m
-            memory: 1G
+            memory: 1024M
       terminationGracePeriodSeconds: 0
       accessCredentials:
       - sshPublicKey:
@@ -290,21 +218,178 @@ spec:
           propagationMethod:
             qemuGuestAgent:
               users:
-              - "fedora"
+              - fedora
       volumes:
-      - dataVolume:
-          name: fedora-dv
-        name: disk0
+      - containerDisk:
+          image: quay.io/containerdisks/fedora:latest
+        name: containerdisk
       - cloudInitConfigDrive:
-          userData: |
-            #!/bin/bash
+          userData: |-
+            #cloud-config
+            password: fedora
+            chpasswd: { expire: False }
+            # Disable SELinux for now, so qemu-guest-agent can write the authorized_keys file
+            # The selinux-policy is too restrictive currently, see open bugs:
+            #   - https://bugzilla.redhat.com/show_bug.cgi?id=1917024
+            #   - https://bugzilla.redhat.com/show_bug.cgi?id=2028762
+            #   - https://bugzilla.redhat.com/show_bug.cgi?id=2057310
+            bootcmd:
+              - setenforce 0
+        name: cloudinitdisk
+EOF
+```
 
-            sudo setenforce Permissive
-            sudo yum install -y qemu-guest-agent
-            sudo systemctl start qemu-guest-agent
-        name: disk1
-END
+### Accessing the VMI using virtctl
 
-kubectl create -f my-vm.yaml
+The user can create a websocket backed network tunnel to a port inside the
+instance by using the `virtualmachineinstances/portforward` subresource of the
+`VirtualMachineInstance`.
+
+One use-case for this subresource is to forward SSH traffic into
+the `VirtualMachineInstance` either from the CLI or a web-UI.
+
+To connect to a `VirtualMachineInstance` from your local machine, `virtctl`
+provides a lightweight SSH client with the `ssh` command, that uses port
+forwarding. Refer to the command's help for more details.
+
+```shell
+virtctl ssh
+```
+
+To transfer files from or to a `VirtualMachineInstance` `virtctl` also
+provides a lightweight SCP client with the `scp` command. Its usage is
+similar to the `ssh` command. Refer to the command's help for more details.
+
+```shell
+virtctl scp
+```
+
+#### Using virtctl as proxy
+
+If you prefer to use your local OpenSSH client, there are two ways of doing
+that in combination with virtctl.
+
+> Note: Most of this applies to the `virtctl scp` command too.
+
+1. The `virtctl ssh` command has a `--local-ssh` option. With this option
+   `virtctl` wraps the local OpenSSH client transparently to the user. The
+   executed SSH command can be viewed by increasing the verbosity (`-v 3`).
+
+```shell
+virtctl ssh --local-ssh -v 3 testvm
+```
+
+2. The `virtctl port-forward` command provides an option to tunnel a single
+   port to your local stdout/stdin. This allows the command to be used in
+   combination with the OpenSSH client's `ProxyCommand` option.
+
+```shell
+ssh -o 'ProxyCommand=virtctl port-forward --stdio=true vmi/testvm.mynamespace 22' fedora@testvm.mynamespace
+```
+
+To provide easier access to arbitrary virtual machines you can add the following
+lines to your SSH `config`:
 
 ```
+Host vmi/*
+   ProxyCommand virtctl port-forward --stdio=true %h %p
+Host vm/*
+   ProxyCommand virtctl port-forward --stdio=true %h %p
+```
+
+This allows you to simply call `ssh user@vmi/testvmi.mynamespace` and your
+SSH config and virtctl will do the rest. Using this method it becomes easy
+to set up different identities for different namespaces inside your SSH
+`config`.
+
+This feature can also be used with Ansible to automate configuration of virtual
+machines running on KubeVirt. You can put the snippet above into its own
+file (e.g. `~/.ssh/virtctl-proxy-config`) and add the following lines to
+your `.ansible.cfg`:
+
+```
+[ssh_connection]
+ssh_args = -F ~/.ssh/virtctl-proxy-config
+```
+
+Note that all port forwarding traffic will be sent over the Kubernetes
+control plane. A high amount of connections and traffic can increase
+pressure on the API server. If you regularly need a high amount of connections
+and traffic consider using a dedicated Kubernetes `Service` instead.
+
+#### Example
+
+1. Create virtual machine and inject SSH public key as explained above
+
+2. SSH into virtual machine
+
+```shell
+# Add --local-ssh to transparently use local OpenSSH client
+virtctl ssh -i id_rsa fedora@testvm
+```
+
+or
+
+```shell
+ssh -o 'ProxyCommand=virtctl port-forward --stdio=true vmi/testvm.mynamespace 22' -i id_rsa fedora@vmi/testvm.mynamespace
+```
+
+4. SCP file to the virtual machine
+
+```shell
+# Add --local-ssh to transparently use local OpenSSH client
+virtctl scp -i id_rsa testfile fedora@testvm:/tmp
+```
+
+or
+
+```shell
+scp -o 'ProxyCommand=virtctl port-forward --stdio=true vmi/testvm.mynamespace 22' -i id_rsa testfile fedora@testvm.mynamespace:/tmp
+```
+
+#### RBAC permissions for Console/VNC/SSH access
+
+##### Using default RBAC cluster roles
+
+Every KubeVirt installation starting with version v0.5.1 ships a set of default
+RBAC cluster roles that can be used to grant users access to
+VirtualMachineInstances.
+
+The `kubevirt.io:admin` and `kubevirt.io:edit` cluster roles have console,
+VNC and SSH respectively port-forwarding access permissions built into them. By
+binding either of these roles to a user, they will have the ability to use
+virtctl to access the console, VNC and SSH.
+
+##### Using custom RBAC cluster role
+
+The default KubeVirt cluster roles grant access to more than just the
+console, VNC and port-forwarding. The `ClusterRole` below demonstrates how
+to craft a custom role, that only allows access to the console, VNC and
+port-forwarding.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: allow-console-vnc-port-forward-access
+rules:
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachineinstances/console
+      - virtualmachineinstances/vnc
+    verbs:
+      - get
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachineinstances/portforward
+    verbs:
+      - update
+```
+
+When bound with a `ClusterRoleBinding` the `ClusterRole` above grants access
+to virtual machines across all namespaces.
+
+In order to reduce the scope to a single namespace, bind this `ClusterRole`
+using a `RoleBinding` that targets a single namespace.


### PR DESCRIPTION
Rework the Accessing Virtual Machines section by:

- Adding description for virtctl ssh and scp
- Simplifying the example YAML definitions
- Using consistent naming
- Various smaller improvements