### PR TITLE
Disk sharing example PVC should use RWX access mode

### DIFF
--- a/docs/virtual_machines/disks_and_volumes.md
+++ b/docs/virtual_machines/disks_and_volumes.md
@@ -1270,7 +1270,7 @@ metadata:
   name: block-pvc
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   volumeMode: Block
   resources:
     requests:


### PR DESCRIPTION
The current example PVC uses a RWO access mode but if the point is to share this disk between multiple VMs then a RWX access mode would be more appropriate.

Signed-off-by: Adam Litke <alitke@redhat.com>