### PR TITLE
passt: Remove note about extra memory when using passt

### DIFF
--- a/docs/virtual_machines/interfaces_and_networks.md
+++ b/docs/virtual_machines/interfaces_and_networks.md
@@ -649,7 +649,6 @@ When no ports are explicitly specified, all ports are forwarded, leading to memo
 
 #### Temporary restrictions: 
 1. `passt` currently only supported as primary network and doesn't allow extra multus networks to be configured on the VM.
-2. A VM with passt binding cannot bind to low ports (less than 1024).
 
 passt interfaces are feature gated; to enable the feature, follow
 [these](../operations/activating_feature_gates.md#how-to-activate-a-feature-gate)

--- a/docs/virtual_machines/interfaces_and_networks.md
+++ b/docs/virtual_machines/interfaces_and_networks.md
@@ -643,7 +643,9 @@ sysctl -w net.core.wmem_max = 33554432
 ```
 sysctl -w fs.file-max = 9223372036854775807
 ```
-3. The `vmi.Spec.Domain.Resources.Requests.Memory` of a passt VM with no explicit ports should be at least 2048M.
+
+*NOTE*: To achieve optimal memory consumption with Passt binding, specify ports required for your workload.
+When no ports are explicitly specified, all ports are forwarded, leading to memory overhead of up to 800 Mi.
 
 #### Temporary restrictions: 
 1. `passt` currently only supported as primary network and doesn't allow extra multus networks to be configured on the VM.


### PR DESCRIPTION
When configuring passt binding with no explicit ports to forward, the memory overhead needed is added automatically, users no longer need to provide the VM with extra memory.

See https://github.com/kubevirt/kubevirt/pull/8716

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>