### PR TITLE
Change to just python3 not a point release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ RESET  := $(shell tput -Txterm sgr0)
 
 TARGET_MAX_CHAR_NUM=20
 
-PYTHON ?= python3.8
+PYTHON ?= python3
 PIP ?= pip3
 
 LOCAL_SERVER_PORT ?= 8000


### PR DESCRIPTION
Update to Makefile to avoid confusion between Netlify at 3.8 and our unified container at 3.10

Signed-off-by: cwilkers <cwilkers@redhat.com>