### PR TITLE
Removing ornamental which statement due to missing in container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,6 @@ endif
 ## Build site. This target should only be used by Netlify and Prow
 build: envvar
 	@echo "${GREEN}Makefile: Build mkdocs site${RESET}"
-	which $(PYTHON)
 	$(PYTHON) -m venv /tmp/venv
 	. /tmp/venv/bin/activate
 	$(PIP) install mkdocs mkdocs-awesome-pages-plugin mkdocs-htmlproofer-plugin


### PR DESCRIPTION
The `which` binary is not installed in the container for back-end updates, and this is causing make to fail.

Signed-off-by: cwilkers <cwilkers@redhat.com>