### PR TITLE
Remove virtctl rename

### DIFF
--- a/docs/virtual_machines/lifecycle.md
+++ b/docs/virtual_machines/lifecycle.md
@@ -84,10 +84,3 @@ Unpausing works similar to pausing:
     # OR
     $ virtctl unpause vmi testvm
 
-
-## Renaming a Virtual Machine
-
-> **Note:** Renaming a Virtual Machine is only possible when a Virtual Machine
-> is stopped, or has a 'Halted' run strategy.
-
-    $ virtctl rename vm_name new_vm_name


### PR DESCRIPTION
`virtctl rename` support got removed by PR [#5646](https://github.com/kubevirt/kubevirt/pull/5646) in  release 0.41.

Signed-off-by: Marcelo Feitoza Parisi <marcelo@feitoza.com.br>