### PR TITLE
Increasing nav depth and disabling sticky_nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,7 @@ markdown_extensions:
 
 theme:
   name: readthedocs
-  navigation_depth: 2
+  navigation_depth: 4
   prev_next_buttons_location: bottom
   include_search_page: true
   search_index_only: false
@@ -28,3 +28,4 @@ theme:
   highlightjs: true
   hljs_languages:
     - yaml
+  sticky_navigation: false


### PR DESCRIPTION
Currently the left pane TOC of the docs is restricted to 2 levels, which decreases the usability of the TOC without navigating to specific pages. This PR increases this to 4 (which is the theme default) makes it easier to navigate additional layers of content from the TOC without needing to scroll through the page. 
This was a recommendation of the CNCF techdocs group. 

This PR also disables sticky navigation: Currently if you load a page and scroll down, the TOC also scrolls, which makes the TOC harder to use as you have to manually scroll the TOC back up to find your place again. Disabling sticky navigation means you can scroll the page without moving the TOC and you don't lose your place. 

Signed-off-by: Andrew Burden <aburden@redhat.com>