### PR TITLE
Fix selinux enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,14 @@ check_spelling: | envvar stop
 		echo; \
 	fi; \
 	if `jq -C  . yaspeller.json > /dev/null 2>&1`; then \
-		${CONTAINER_ENGINE} run -it --rm --name userguide -v ${PWD}:/srv:ro${SELINUX_ENABLED} -v ${PWD}/yaspeller.json:/srv/yaspeller.json:ro${SELINUX_ENABLED} --workdir=/srv ${IMGTAG} /bin/bash -c 'yaspeller -c /srv/yaspeller.json --only-errors --ignore-tags iframe,img,code,kbd,object,samp,script,style,var /srv' | sed -e 's/\/srv/./g'; \
+		${CONTAINER_ENGINE} run \
+			-it \
+			--rm \
+			--name userguide \
+			-v ${PWD}:/srv:ro${SELINUX_ENABLED} \
+			-v ${PWD}/yaspeller.json:/srv/yaspeller.json:ro${SELINUX_ENABLED} \
+			--workdir=/srv ${IMGTAG} \
+			/bin/bash -c 'yaspeller -c /srv/yaspeller.json --only-errors --ignore-tags iframe,img,code,kbd,object,samp,script,style,var /srv' | sed -e 's/\/srv/./g'; \
 	else \
 		echo "${RED}ERROR: yaspeller dictionary file does not exist or is invalid json ${RESET}"; \
 		exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ run: | envvar stop
 		--name userguide \
 		-p ${LOCAL_SERVER_PORT}:8000 \
 		-v ${PWD}:/srv:ro${SELINUX_ENABLED} \
-		-v /dev/null:/srv/Gemfile.lock:rw${SELINUX_ENABLED} \
+		-v /dev/null:/srv/Gemfile.lock:rw \
 		--mount type=tmpfs,destination=/srv/site \
 		${IMGTAG} \
 		/bin/bash -c "mkdocs build -f /srv/mkdocs.yml && mkdocs serve -f /srv/mkdocs.yml -a 0.0.0.0:8000"


### PR DESCRIPTION
Still bothers me that a `make run` would appear to be successfull

```
Makefile: Run site
podman run \
        -d \
        --name userguide \
        -p 8000:8000 \
        -v /home/toso/src/kubevirt/user-guide:/srv:ro \
        -v /dev/null:/srv/Gemfile.lock:rw \
        --mount type=tmpfs,destination=/srv/site \
        localhost/kubevirt-user-guide \
        /bin/bash -c "mkdocs build -f /srv/mkdocs.yml && mkdocs serve -f /srv/mkdocs.yml -a 0.0.0.0:8000"
1550257a2609c84964efdc1082bcfeedab9d171f7d431e3ac1847e10f8a8cf66

Makefile: Server now running at [http://localhost:8000]
```

When the actual result is

```
toso@tapioca ~/s/k/user-guide (fix-selinux-enabled)> podman ps
CONTAINER ID  IMAGE       COMMAND     CREATED     STATUS      PORTS       NAMES

toso@tapioca ~/s/k/user-guide (fix-selinux-enabled)> podman container logs userguide
Usage: mkdocs build [OPTIONS]
Try 'mkdocs build -h' for help.

Error: Invalid value for '-f' / '--config-file': '/srv/mkdocs.yml': Permission denied
```

But I'm afraid of Makefiles. They haunt me on my sleep. A simple `if $engine ps --filter name=userguide`  there would not mislead new users and a `else;  $engine container logs userguide` would point out to the selinux/permission issue.

Cheers,  