### PR TITLE
Add KubeVirt secondary scheduler page to index

### DIFF
--- a/docs/operations/.pages
+++ b/docs/operations/.pages
@@ -10,6 +10,7 @@ nav:
   - hotplug_volumes.md
   - client_passthrough.md
   - snapshot_restore_api.md
+  - scheduler.md
   - hugepages.md
   - component_monitoring.md
   - authorization.md


### PR DESCRIPTION
The KubeVirt secondary scheduler page is missing. Therefore, users are unable to see it through the website.