### PR TITLE
Remove virtctl rename

### DIFF
--- a/docs/virtual_machines/lifecycle.md
+++ b/docs/virtual_machines/lifecycle.md
@@ -83,11 +83,3 @@ Unpausing works similar to pausing:
     $ virtctl unpause vm testvm
     # OR
     $ virtctl unpause vmi testvm
-
-
-## Renaming a Virtual Machine
-
-> **Note:** Renaming a Virtual Machine is only possible when a Virtual Machine
-> is stopped, or has a 'Halted' run strategy.
-
-    $ virtctl rename vm_name new_vm_name


### PR DESCRIPTION
According to [PR 5564](https://github.com/kubevirt/kubevirt/pull/5564), VirtualMachine renaming isn't supported anymore.

Signed-off-by: Marcelo Feitoza Parisi <marcelo@feitoza.com.br>