### PR TITLE
instancetypes: Fix headings and link from virtctl docs

### DIFF
--- a/docs/virtual_machines/creating_vms.md
+++ b/docs/virtual_machines/creating_vms.md
@@ -51,7 +51,7 @@ If a prefix was not supplied the cluster scoped resources will be used by
 default.
 
 To
-infer [instance types and/or preferences](./instancetypes.md#inferring-defaults-from-a-volume)
+infer [instance types and/or preferences](./instancetypes.md#inferFromVolume)
 from the volume used to boot the virtual machine add the following flags:
 
 ```shell

--- a/docs/virtual_machines/instancetypes.md
+++ b/docs/virtual_machines/instancetypes.md
@@ -304,7 +304,7 @@ $ kubectl get vmi/vm-cirros-csmall -o json | jq .spec.domain.cpu
 }
 ```
 
-### Inferring defaults from a Volume
+## inferFromVolume
 
 The `inferFromVolume` attribute of both the `InstancetypeMatcher` and `PreferenceMatcher` allows a user to request that defaults are inferred from a volume. When requested, KubeVirt will look for the following labels on the underlying `PVC`, `DataSource` or `DataVolume` to determine the default name and kind:
 
@@ -386,7 +386,7 @@ kubectl get vms/cirros -o json | jq '.spec.instancetype, .spec.preference'
 }
 ```
 
-### Common Instance Types
+## common-instancetypes
 
 A set of common instance types and preferences are provided through the [`kubevirt/common-instancetypes`](https://github.com/kubevirt/common-instancetypes) project. To install all resources provided by the project, simply build with `kustomize` and apply:
 


### PR DESCRIPTION
Some recently introduced headings were one level too deep. This change also shortens both titles and updates the associated link from the virtctl docs.