### PR TITLE
Re-arrange contributor guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,20 +7,17 @@ hide:
 
 ## Prerequisites
 
-Reviewing the following will prepare you for contributing
+Reviewing the following will prepare you for contributing:
+
+* You should be comfortable with git. Most contributions follow the GitHub workflow of fork, branch, commit, open pull request, review changes, and merge to work effectively in the KubeVirt community.  If you're new to git, [git-scm.com](https://git-scm.com/doc) has a nice set of tutorials.
+* Familiarize yourself with the various repositories of the [KubeVirt](https://github.com/kubevirt) GitHub organization.
+* Try the one of our [quick start labs](https://kubevirt.io/user-guide/) on [killercoda](https://killercoda.com/kubevirt), [minikube](https://kubevirt.io/quickstart_minikube/), or [kind](https://kubevirt.io/quickstart_kind/).
+* See the "Other ways to contribute" section below.
 
 For code contributors:
 
 * You need to be familiar with writing code in golang.  See the [golang tour](https://tour.golang.org/welcome/1) to familiarize yourself.
 * Read the Developer [contribution page](https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md) and the [getting started page](https://github.com/kubevirt/kubevirt/blob/main/docs/getting-started.md).
-
-For all contributors:
-
-* You need to be comfortable with git, GitHub workflow of fork, branch, commit, open pull request, reviewing changes, and merge to work effectively in the KubeVirt community.  If you're new to git git-scm.com very nice tutorials [here](https://git-scm.com/doc).
-* Familiarize yourself with the various repositories of the [KubeVirt](https://github.com/kubevirt) GitHub organization.
-* Try the Deploy KubeVirt on [minikube](https://kubevirt.io/quickstart_minikube/) or [kind](https://kubevirt.io/quickstart_kind/) quickstart lab.
-* Try the [Using KubeVirt](https://kubevirt.io/labs/kubernetes/lab1.html) lab.
-* See the other ways to contribute section
 
 ## Your first contribution
 
@@ -34,3 +31,4 @@ The following will help you decide where to start
 
 * Visit the KubeVirt [community page](https://kubevirt.io/community/), participate on Twitter or Slack, learn about local meetups and events.
 * Visit the KubeVirt [website repository](https://github.com/kubevirt/kubevirt.github.io) and submit a blog post, case study or lab.
+* Visit the KubeVirt [user-guide repository](https://github.com/kubevirt/user-guide) and find feature documentation that could use an update.


### PR DESCRIPTION
Moved "for code contributors" section to after general content, updated examples under "Try...", and added user-guide to "other ways" section.