### PR TITLE
Add ignition documentation

### DIFF
--- a/docs/virtual_machines/disks_and_volumes.md
+++ b/docs/virtual_machines/disks_and_volumes.md
@@ -228,6 +228,9 @@ datasource may look like this:
             secretRef:
               name: testsecret
 
+The `cloudInitConfigDrive` can also be used to configure VMs with Ignition.
+You just need to replace the cloud-init data by the Ignition data.
+
 ### persistentVolumeClaim
 
 Allows connecting a `PersistentVolumeClaim` to a VM disk.


### PR DESCRIPTION
The documentation regarding Ignition is nearly non-existent. The only reference to it is a blog post [here](https://kubevirt.io/2018/ignition-support.html) which is not relevant anymore (see https://github.com/kubevirt/kubevirt/pull/9212 and the corresponding Slack conversation).

This PR add documentation about how to use Ignition with Kubevirt. 