### PR TITLE
Fix incorrect indentation for UEFI example (#696)

### DIFF
--- a/docs/virtual_machines/virtual_hardware.md
+++ b/docs/virtual_machines/virtual_hardware.md
@@ -57,9 +57,9 @@ It is possible to utilize UEFI/OVMF by setting a value via
           - disk:
               bus: virtio
             name: containerdisk
-          features:
-            smm:
-              enabled: true
+        features:
+          smm:
+            enabled: true
         firmware:
           # this sets the bootloader type
           bootloader:


### PR DESCRIPTION
Super tiny change, just unindent the offending `features` section by one level.