### PR TITLE
Adding important community links to contributor page

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,10 +5,15 @@ hide:
 
 # Contributing
 
+Welcome!! And thank you for taking the first step to contributing to the KubeVirt project. On this page you should be able to find all the information required to get started on your contirbution journey, as well as information on how to become a community member and grow into roles of responsibility. 
+
+If you think something might be missing from this page, please help us by [raising a bug](https://github.com/kubevirt/user-guide/issues)!
+
 ## Prerequisites
 
 Reviewing the following will prepare you for contributing:
 
+* If this is your first step in the world of open source, consider reading the CNCF's [Start Contributing to Open Source](https://contribute.cncf.io/contributors/getting-started/) page for an introduction to key concepts.
 * You should be comfortable with git. Most contributions follow the GitHub workflow of fork, branch, commit, open pull request, review changes, and merge to work effectively in the KubeVirt community.  If you're new to git, [git-scm.com](https://git-scm.com/doc) has a nice set of tutorials.
 * Familiarize yourself with the various repositories of the [KubeVirt](https://github.com/kubevirt) GitHub organization.
 * Try the one of our [quick start labs](https://kubevirt.io/user-guide/) on [killercoda](https://killercoda.com/kubevirt), [minikube](https://kubevirt.io/quickstart_minikube/), or [kind](https://kubevirt.io/quickstart_kind/).
@@ -17,15 +22,24 @@ Reviewing the following will prepare you for contributing:
 For code contributors:
 
 * You need to be familiar with writing code in golang.  See the [golang tour](https://tour.golang.org/welcome/1) to familiarize yourself.
-* Read the Developer [contribution page](https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md) and the [getting started page](https://github.com/kubevirt/kubevirt/blob/main/docs/getting-started.md).
+* To contribute to the core of the project, read the Developer [contribution page](https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md) and the [getting started page](https://github.com/kubevirt/kubevirt/blob/main/docs/getting-started.md) in the kubevirt/kubevirt repo.
+* Alternatively, to contribute to its storage management add-on, check out the [kubevirt/containerized-data-importer](https://github.com/kubevirt/containerized-data-importer/tree/main) (CDI) repo, and their [contribution page](https://github.com/kubevirt/containerized-data-importer/blob/main/CONTRIBUTING.md).
 
 ## Your first contribution
 
-The following will help you decide where to start
+The following will help you decide where to start:
 
 * Check a repository issues list and label `good-first-issue` for issues that make good entry points.
 * Open a pull request using GitHub to documentation. The tutorials found here can be helpful https://lab.github.com/
 * Review a pull request from other community members for accuracy and language.
+
+## Important community resources
+
+You should familiarize yourself with the following documents, which are critical to being a member of the community:
+
+* [Code of Conduct](https://github.com/kubevirt/kubevirt/blob/main/CODE_OF_CONDUCT.md): Everyone is expected to abide by the CoC to ensure an open and welcoming environment. Our CoC is based off the [CNCF Code of conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md) which also has a variety of translations. 
+* [Our community membership policy](https://github.com/kubevirt/community/blob/main/membership_policy.md): How to become a member and grow into roles of responsibility.
+* [Project governance](https://github.com/kubevirt/community/blob/main/GOVERNANCE.md): Project Maintainer responsibilities.
 
 ## Other ways to contribute
 


### PR DESCRIPTION
We guide new contributors to the user-guide contribution page, so it makes sense to include links from there to some of the core documents (governance, CoC, membership policy) to becoming an org member and how a new contributor can grow into areas of responsibility. 

Also adding the CDI repo as an alternative for new users interested in contributing code.