### PR TITLE
Fix indentation of features stanza in BIOS/UEFI

### DIFF
--- a/docs/virtual_machines/virtual_hardware.md
+++ b/docs/virtual_machines/virtual_hardware.md
@@ -57,9 +57,9 @@ It is possible to utilize UEFI/OVMF by setting a value via
           - disk:
               bus: virtio
             name: containerdisk
-          features:
-            smm:
-              enabled: true
+        features:
+          smm:
+            enabled: true
         firmware:
           # this sets the bootloader type
           bootloader:


### PR DESCRIPTION
`features` is currently nexted under devices in the docs for BIOS/UEFI.

It should be alongside devices rather than under it.