### PR TITLE
Enabling footnotes feature

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ edit_uri: https://github.com/kubevirt/user-guide/edit/main/docs/
 
 markdown_extensions:
   - admonition
+  - footnotes
   - toc:
       permalink: true
   - pymdownx.highlight:


### PR DESCRIPTION
Adding the [footnotes features](https://squidfunk.github.io/mkdocs-material/reference/footnotes/) for material

As seen in #718 footnotes can be pretty useful in a place where an admonition might be obtrusive.