### PR TITLE
Add pages for new section about virt debugging

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -6,3 +6,4 @@ nav:
   - Virtual Machines: virtual_machines
   - Release Notes: release_notes.md
   - contributing.md
+  - Virtualization Debugging: debug_virt_stack

--- a/docs/debug_virt_stack/.pages
+++ b/docs/debug_virt_stack/.pages
@@ -1,0 +1,6 @@
+nav:
+  - logging.md
+  - privileged-node-debugging.md
+  - virsh-commands.md
+  - launch-qemu-strace.md
+  - launch-qemu-gdb.md


### PR DESCRIPTION
Add pages for the new section about virtualization stack debugging added by https://github.com/kubevirt/user-guide/pull/725