### PR TITLE
docs, vm: Add network binding plugins guide

### DIFF
--- a/docs/virtual_machines/.pages
+++ b/docs/virtual_machines/.pages
@@ -10,6 +10,7 @@ nav:
   - numa.md
   - disks_and_volumes.md
   - interfaces_and_networks.md
+  - network_binding_plugins.md
   - istio_service_mesh.md
   - networkpolicy.md
   - host-devices.md

--- a/docs/virtual_machines/interfaces_and_networks.md
+++ b/docs/virtual_machines/interfaces_and_networks.md
@@ -630,6 +630,11 @@ Tracking issue - https://github.com/kubevirt/kubevirt/issues/7184
 
 ### passt
 
+> **Warning**: The core binding is being deprecated and targeted for removal
+> in v1.3 .
+> As an alternative, the same functionality is introduced and available as a
+> [binding plugin](net_binding_plugins/passt.md).
+
 `passt` is a new approach for user-mode networking which can be used as a simple replacement for Slirp (which is practically dead).
 
 `passt` is a universal tool which implements a translation layer between a Layer-2 network interface and native

--- a/docs/virtual_machines/interfaces_and_networks.md
+++ b/docs/virtual_machines/interfaces_and_networks.md
@@ -527,46 +527,6 @@ In case no image is registered, Kubevirt will use the following default image: `
 
 > **Note:** On disconnected clusters it will be necessary to mirror Slirp binding plugin image to the cluster registry.
 
-### Network binding plugins
-Since v1.1.0, Kubevirt enables delegating network binding configurations to a hook sidecar.
-
-The sidecar container is added to the VM virt-launcher pod using the registered network binding plugin image in Kubevirt config.
-
-To register a network binding plugin image, specify the image in Kubevirt config as follows:
-```yaml
-apiVersion: kubevirt.io/v1
-kind: KubeVirt
-metadata:
-  name: kubevirt
-  namespace: kubevirt
-spec:
-  configuration:
-    network:
-      binding:
-        slirp:
-          sidecarImage: "kubevirt/network-slirp-plugin"
-```
-
-Use the binding by specifying it in the VM spec:
-```yaml
-apiVersion: kubevirt.io/v1
-kind: VirtualMachine
-metadata:
-  name: example-vm-slirp
-spec:
-  template:
-    spec:
-      domain:
-        devices:
-          interfaces:
-          - name: podnetwork
-            binding:
-              name: slirp
-    networks:
-    - name: podnetwork
-      pod: {}
-```
-
 ### masquerade
 
 In `masquerade` mode, KubeVirt allocates internal IP addresses to

--- a/docs/virtual_machines/interfaces_and_networks.md
+++ b/docs/virtual_machines/interfaces_and_networks.md
@@ -518,14 +518,17 @@ fields.
 More information about SLIRP mode can be found in [QEMU
 Wiki](https://wiki.qemu.org/Documentation/Networking#User_Networking_.28SLIRP.29).
 
-#### Slirp network binding plugin
-Since v1.1.0, Kubevirt delegates Slirp network configuration to a hook sidecar using Slirp network binding plugin by default.
+> **Note**: Since v1.1.0, Kubevirt delegates Slirp network configuration to
+> the [Slirp network binding plugin](net_binding_plugins/slirp.md#slirp-network-binding-plugin) by default.
+> In case the binding plugin is not registered,
+> Kubevirt will use the following default image:
+> `quay.io/kubevirt/network-slirp-binding:20230830_638c60fc8`.
 
-In case no image is registered, Kubevirt will use the following default image: `quay.io/kubevirt/network-slirp-binding:20230830_638c60fc8`.
+> **Note:** In the next release (v1.2.0) no default image will be set by Kubevirt,
+> registering an image will be mandatory.
 
-> **Note:** In the next release (v1.2.0) no default image will be set by Kubevirt, registering an image will be mandatory.
-
-> **Note:** On disconnected clusters it will be necessary to mirror Slirp binding plugin image to the cluster registry.
+> **Note:** On disconnected clusters it will be necessary
+> to mirror Slirp binding plugin image to the cluster registry.
 
 ### masquerade
 

--- a/docs/virtual_machines/net_binding_plugins/passt.md
+++ b/docs/virtual_machines/net_binding_plugins/passt.md
@@ -1,0 +1,211 @@
+# Passt binding
+
+## Overview
+
+[Plug A Simple Socket Transport](https://passt.top/passt/about/) is an enhanced
+alternative to [SLIRP](https://en.wikipedia.org/wiki/Slirp), providing user-space
+network connectivity.
+
+`passt` is a universal tool which implements a translation layer between
+a Layer-2 network interface and native Layer -4 sockets (TCP, UDP, ICMP/ICMPv6 echo)
+on a host.
+
+Its main benefits are:
+
+- Doesn't require extra network capabilities as CAP_NET_RAW and CAP_NET_ADMIN.
+- Allows integration with service meshes (which expect applications to run locally) out of the box.
+- Supports IPv6 out of the box (in contrast to the existing bindings which require configuring IPv6
+  manually).
+
+### Functionality support
+| Functionality                                  | Support |
+|------------------------------------------------|---------|
+| Migration support                              | No      |
+| Service Mesh support                           | Yes     |
+| Pod IP in guest                                | Yes     |
+| Custom CIDR in guest                           | No      |
+| Require extra capabilities (on pod) to operate | No      |
+| Primary network (pod network)                  | Yes     |
+| Secondary network                              | No      |
+
+### Node optimization requirements/recommendations:
+
+1. To get better performance the node should be configured with:
+```
+sysctl -w net.core.rmem_max = 33554432
+sysctl -w net.core.wmem_max = 33554432
+```
+2. To run multiple passt VMs with no explicit ports, the node's `fs.file-max` should be increased
+   (for a VM forwards all IPv4 and IPv6 ports, for TCP and UDP, passt needs to create ~2^18 sockets):
+```
+sysctl -w fs.file-max = 9223372036854775807
+```
+
+> **NOTE**: To achieve optimal memory consumption with Passt binding,
+> specify ports required for your workload.
+> When no ports are explicitly specified, all ports are forwarded,
+> leading to memory overhead of up to 800 Mi.
+
+## Passt network binding plugin
+[v1.1.0]
+
+The binding plugin replaces the experimental core passt binding implementation
+(including its API).
+
+> **Note**: The network binding plugin infrastructure and the passt plugin
+> specifically are in Alpha stage. Please use them with care, preferably
+> on a non-production deployment.
+
+The passt binding plugin consists of the following components:
+
+- Passt CNI plugin.
+- Sidecar image.
+
+As described in the [definition & flow](#definition--flow) section,
+the passt plugin needs to:
+
+- Deploy the CNI plugin binary on the nodes.
+- Define a NetworkAttachmentDefinition that points to the CNI plugin.
+- Assure access to the sidecar image.
+- Enable the network binding plugin framework FG.
+- Register the binding plugin on the Kubevirt CR.
+- Reference the network binding by name from the VM spec interface.
+
+And in detail:
+
+### Passt CNI deployment on nodes
+The CNI plugin binary can be retrieved directly from the kubevirt release
+assets (on GitHub) or to be built from its
+[sources](https://github.com/kubevirt/kubevirt/tree/release-1.1/cmd/cniplugins/passt-binding).
+
+> **Note**: The kubevirt project uses Bazel to build the binaries and container images.
+> For more information in how to build the whole project, visit the developer
+> [getting started guide](https://github.com/kubevirt/kubevirt/blob/release-1.1/docs/getting-started.md).
+
+Once the binary is ready, you may rename it to a meaningful name
+(e.g. `kubevirt-passt-binding`).
+This name is used in the NetworkAttachmentDefinition configuration.
+
+Copy the binary to each node in your cluster.
+The location of the CNI plugins may vary between platforms and versions.
+One common path is `/opt/cni/bin/`.
+
+### Passt NetworkAttachmentDefinition
+The configuration needed for passt is minimalistic:
+
+```yaml
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: netbindingpasst
+spec:
+  config: '{
+            "cniVersion": "1.0.0",
+            "name": "netbindingpasst",
+            "plugins": [
+              {
+                "type": "kubevirt-passt-binding"
+              }
+            ]
+  }'
+```
+
+The object should be created in a "default" namespace where all other namespaces
+can access, or, in the same namespace the VMs reside in.
+
+### Passt sidecar image
+Passt sidecar image is built and pushed to
+[kubevirt quay repository](https://quay.io/repository/kubevirt/network-passt-binding).
+
+The sidecar sources can be found
+[here](https://github.com/kubevirt/kubevirt/tree/release-1.1/cmd/sidecars/network-passt-binding).
+
+The relevant sidecar image needs to be accessible by the cluster and
+specified in the Kubevirt CR when registering the network binding plugin.
+
+### Feature Gate
+If not already set, add the `NetworkBindingPlugins` FG.
+```
+kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-",   "value": "NetworkBindingPlugins"}]'
+```
+
+> **Note**: The specific passt plugin has no FG by its own. It is up to the cluster
+> admin to decide if the plugin is to be available in the cluster.
+> The passt binding is still in evaluation, use it with care.
+
+### Passt Registration
+As described in the [registration section](#register), passt binding plugin
+configuration needs to be added to the kubevirt CR.
+
+To register the passt binding, patch the kubevirt CR as follows:
+```yaml
+kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "path": "/spec/configuration/network",   "value": {
+            "binding": {
+                "passt": {
+                    "networkAttachmentDefinition": "default/netbindingpasst",
+                    "sidecarImage": "quay.io/kubevirt/network-passt-binding:20231205_29a16d5c9"
+                }
+            }
+        }}]'
+```
+
+The NetworkAttachmentDefinition and sidecarImage values should correspond with the
+names used in the previous sections, [here](#passt-networkattachmentdefinition)
+and [here](#passt-sidecar-image).
+
+### VM Passt Network Interface
+Set the VM network interface binding name to reference the one defined in the
+kubevirt CR.
+
+```yaml
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  labels:
+    kubevirt.io/vm: vm-net-binding-passt
+  name: vm-net-binding-passt
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: vm-net-binding-passt
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+          interfaces:
+          - name: passtnet
+            binding:
+              name: passt
+            ports:
+            - name: http
+              port: 80
+              protocol: TCP
+          rng: {}
+        resources:
+          requests:
+            memory: 1024M
+      networks:
+      - name: passtnet
+        pod: {}
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:v1.1.0
+        name: containerdisk
+      - cloudInitNoCloud:
+          networkData: |
+            version: 2
+            ethernets:
+              eth0:
+                dhcp4: true
+        name: cloudinitdisk
+```

--- a/docs/virtual_machines/net_binding_plugins/slirp.md
+++ b/docs/virtual_machines/net_binding_plugins/slirp.md
@@ -1,0 +1,110 @@
+# Slirp
+
+## Overview
+
+[SLIRP](https://en.wikipedia.org/wiki/Slirp) provides user-space
+network connectivity.
+
+> **Note:** in `slirp` mode, the only supported protocols are TCP and
+> UDP. ICMP is *not* supported.
+
+## Slirp network binding plugin
+[v1.1.0]
+
+The binding plugin replaces the [core `slirp` binding](interfaces_and_networks.md#slirp)
+API.
+
+> **Note**: The network binding plugin infrastructure is in Alpha stage.
+> Please use them with care.
+
+The slirp binding plugin consists of the following components:
+
+- Sidecar image.
+
+As described in the [definition & flow](#definition--flow) section,
+the slirp plugin needs to:
+
+- Assure access to the sidecar image.
+- Enable the network binding plugin framework FG.
+- Register the binding plugin on the Kubevirt CR.
+- Reference the network binding by name from the VM spec interface.
+
+> **Note**: In order for the core slirp binding to use the network binding plugin
+> the registered name for this binding should be `slirp`.
+
+### Feature Gate
+If not already set, add the `NetworkBindingPlugins` FG.
+```
+kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-",   "value": "NetworkBindingPlugins"}]'
+```
+
+> **Note**: The specific slirp plugin has no FG by its own. It is up to the cluster
+> admin to decide if the plugin is to be available in the cluster.
+
+### Slirp Registration
+As described in the [registration section](#register), slirp binding plugin
+configuration needs to be added to the kubevirt CR.
+
+To register the slirp binding, patch the kubevirt CR as follows:
+```yaml
+kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "path": "/spec/configuration/network",   "value": {
+            "binding": {
+                "slirp": {
+                    "sidecarImage": "quay.io/kubevirt/network-slirp-binding:v1.1.0"
+                }
+            }
+        }}]'
+```
+
+### VM Slirp Network Interface
+Set the VM network interface binding name to reference the one defined in the
+kubevirt CR.
+
+```yaml
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  labels:
+    kubevirt.io/vm: vm-net-binding-slirp
+  name: vm-net-binding-passt
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: vm-net-binding-slirp
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+          interfaces:
+          - name: slirpnet
+            binding:
+              name: slirp
+          rng: {}
+        resources:
+          requests:
+            memory: 1024M
+      networks:
+      - name: slirpnet
+        pod: {}
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:v1.1.0
+        name: containerdisk
+      - cloudInitNoCloud:
+          networkData: |
+            version: 2
+            ethernets:
+              eth0:
+                dhcp4: true
+        name: cloudinitdisk
+```

--- a/docs/virtual_machines/network_binding_plugins.md
+++ b/docs/virtual_machines/network_binding_plugins.md
@@ -1,0 +1,229 @@
+# Network Binding Plugins
+[v1.1.0, Alpha feature]
+
+A modular plugin which integrates with Kubevirt to implement a
+network binding.
+
+## Overview
+
+### Network Connectivity
+In order for a VM to have access to external network(s), several layers
+need to be defined and configured, depending on the connectivity characteristics
+needs.
+
+These layers include:
+
+- Host connectivity: Network provider.
+- Host to Pod connectivity: CNI.
+- Pod to domain connectivity: Network Binding.
+
+This guide focuses on the Network Binding portion.
+
+### Network Binding
+The network binding defines how the domain (VM) network interface is wired
+in the VM pod through the domain to the guest.
+
+The network binding includes:
+
+- Domain vNIC configuration.
+- Pod network configuration (optional).
+- Services to deliver network details to the guest (optional).
+  E.g. DHCP server to pass the IP configuration to the guest.
+
+### Plugins
+The network bindings have been part of Kubevirt core API and codebase.
+With the increase of the number of network bindings added and
+frequent requests to tweak and change the existing network bindings,
+a decision has been made to create a network binding plugin infrastructure.
+
+The plugin infrastructure provides means to compose a network binding plugin
+and integrate it into Kubevirt in a modular manner.
+
+Kubevirt is providing several network binding plugins as references.
+The following plugins are available:
+
+- slirp [v1.1.0]
+- passt [v1.1.0]
+- macvtap [v1.1.1]
+
+## Definition & Flow
+A network binding plugin configuration consist of the following steps:
+
+- Deploy network binding optional components:
+
+  - Binding CNI plugin.
+  - Binding NetworkAttachmentDefinition manifest.
+  - Access to the sidecar image.
+  - Enable `NetworkBindingPlugins` Feature Gate (FG).
+
+- Register network binding.
+- Assign VM network interface binding.
+
+### Deployment
+Depending on the plugin, some components need to be deployed in the cluster.
+Not all network binding plugins require all these components, therefore
+these steps are optional.
+
+- Binding CNI plugin: When it is required to change the pod network stack
+  (and a core domain-attachment is not a fit), a custom CNI plugin is
+  composed to serve the network binding plugin.
+
+  This binary needs to be deployed on each node of the cluster, like any
+  other CNI plugin.
+
+  The binary can be built from source or consumed from an existing artifact.
+
+> **Note**: The location of the CNI plugins binaries depends on the platform
+> used and its configuration. A frequently used path for such binaries is
+> `/opt/cni/bin/`.
+
+- Binding NetworkAttachmentDefinition: It references the binding CNI plugin,
+  with optional configuration settings.
+  The manifest needs to be deployed on the cluster at a namespace which
+  is accessible by the VM and its pod.
+
+Example:
+```yaml
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: netbindingpasst
+spec:
+  config: '{
+            "cniVersion": "1.0.0",
+            "name": "netbindingpasst",
+            "plugins": [
+              {
+                "type": "cni-passt-binding-plugin"
+              }
+            ]
+  }'
+```
+
+> **Note**: It is possible to deploy the NetworkAttachmentDefinition
+> on the `default` namespace, where all other namespaces can access it.
+> Nevertheless, it is recommended (for security reasons) to define the
+> NetworkAttachmentDefinition in the same namespace the VM resides.
+
+- [Multus](https://github.com/k8snetworkplumbingwg/multus-cni): In order
+  for the network binding CNI and the NetworkAttachmentDefinition to operate,
+  there is a need to have Multus deployed on the cluster.
+  For more information, check the
+  [Quickstart Intallation Guide](https://github.com/k8snetworkplumbingwg/multus-cni#quickstart-installation-guide).
+
+- Sidecar image: When a core domain-attachment is not a fit, a sidecar is
+  used to configure the vNIC domain configuration.
+  In a more complex scenarios, the sidecar also runs services like DHCP to
+  deliver IP information to the guest.
+
+  The sidecar image is built and usually pushed to an image registry for
+  consumption. Therefore, the cluster needs to have access to the image.
+  
+  The image can be built from source and pushed to an accessible registry
+  or used from a given registry that already contains it.
+
+- Feature Gate
+  The network binding plugin is currently (v1.1.0) in Alpha stage, protected
+  by a feature gate (FG) named `NetworkBindingPlugins`.
+
+  It is therefore necessary to set the FG in the Kubevirt CR.
+
+  Example (valid when the FG subtree is already defined):
+```
+kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-",   "value": "NetworkBindingPlugins"}]'
+```
+
+### Register
+In order to use a network binding plugin, the cluster admin needs to register
+the binding.
+Registration includes the addition of the binding name with all its parameters
+to the Kubevirt CR.
+
+The following (optional) parameters are currently supported (as of v1.1.1):
+
+- networkAttachmentDefinition: Use the <namespace/object-name> format to specify
+  the [NetworkAttachementDefinition](https://github.com/k8snetworkplumbingwg/multi-net-spec/blob/master/v1.0/%5Bv1%5D%20Kubernetes%20Network%20Custom%20Resource%20Definition%20De-facto%20Standard.md)
+  that defines the CNI plugin and the configuration the binding plugin uses.
+  Used when the binding plugin needs to change the pod network namespace.
+- sidecarImage: Specify a container image in a registry.
+  Used when the binding plugin needs to modify the domain vNIC configuration
+  or when a service needs to be executed (e.g. DHCP server).
+- domainAttachmentType: Specify the name of a core domain attachment type.
+  A possible alternative to a sidecar, to configure the domain vNIC.
+  At the moment (v1.1.1) only a single type is supported: `tap`.
+
+  When both the `domainAttachmentType` and `sidecarImage` are specified,
+  the domain will first be configured according to the `domainAttachmentType`
+  and then the `sidecarImage` may modify it.
+
+> **Note**: In some deployments the Kubevirt CR is controlled by an external
+> controller (e.g. [HCO](https://github.com/kubevirt/hyperconverged-cluster-operator)).
+> In such cases, make sure to configure the wrapper operator/controller so the
+> changes will get preserved.
+
+Example (the `passt` binding):
+```
+kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "path": "/spec/configuration/network",   "value": {
+            "binding": {
+                "passt": {
+                    "networkAttachmentDefinition": "default/netbindingpasst",
+                    "sidecarImage": "quay.io/kubevirt/network-passt-binding:20231205_29a16d5c9"
+                }
+            }
+        }}]'
+```
+
+### VM Network Interface
+When configuring the VM/VMI network interface, the binding plugin name
+can be specified. If it exists in the Kubevirt CR, it will be used
+to setup the network interface.
+
+Example (`passt` binding):
+```yaml
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  labels:
+    kubevirt.io/vm: vm-net-binding-passt
+  name: vm-net-binding-passt
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: vm-net-binding-passt
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+          interfaces:
+          - name: passtnet
+            binding:
+              name: passt
+          rng: {}
+        resources:
+          requests:
+            memory: 1024M
+      networks:
+      - name: passtnet
+        pod: {}
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:v1.1.0
+        name: containerdisk
+      - cloudInitNoCloud:
+          networkData: |
+            version: 2
+            ethernets:
+              eth0:
+                dhcp4: true
+        name: cloudinitdisk
+```

--- a/docs/virtual_machines/network_binding_plugins.md
+++ b/docs/virtual_machines/network_binding_plugins.md
@@ -231,3 +231,4 @@ spec:
 ## Available network binding plugins
 
 - [Passt](net_binding_plugins/passt.md)
+- [Slirp](net_binding_plugins/slirp.md)

--- a/docs/virtual_machines/network_binding_plugins.md
+++ b/docs/virtual_machines/network_binding_plugins.md
@@ -227,3 +227,7 @@ spec:
                 dhcp4: true
         name: cloudinitdisk
 ```
+
+## Available network binding plugins
+
+- [Passt](net_binding_plugins/passt.md)


### PR DESCRIPTION
Describe the network binding plugins infrastructure for users.
Includes detailed explanation with examples.

The following binding plugins are included:
- Passt
-  slirp binding plugin
 
In follow up PRs, the following subject should be covered:
- Domain Attachement
- macvtap binding plugin