### PR TITLE
Revert "IsolateEmulatorThread with full-pcpus-only (#736)"

### DIFF
--- a/docs/virtual_machines/dedicated_cpu_resources.md
+++ b/docs/virtual_machines/dedicated_cpu_resources.md
@@ -114,26 +114,6 @@ Example:
             cpu: 2
             memory: 2Gi
 
-When the following conditions are met:
-- The compute node has [SMT](https://en.wikipedia.org/wiki/Simultaneous_multithreading) enabled
-- Kubelet's CPUManager policy is set to static - [full-pcpus-only](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy-options)
-- The VM is configured to have an even number of CPUs
-- `dedicatedCpuPlacement` and `isolateEmulatorThread` are enabled
-
-The VM is scheduled, but rejected by the kubelet with the following event:
-```
-SMT Alignment Error: requested 3 cpus not multiple cpus per core = 2
-```
-
-In order to address this issue:
-1. Enable the `CPUManagerPolicyBetaOptions` feature gate in the KubeVirt CR.
-2. Add the following annotation to the VMI:
-```yaml
-kubevirt.io/CPUManagerPolicyBetaOptions: full-pcpus-only
-```
-
-It will cause KubeVirt to allocate two dedicated CPUs for the emulator thread isolation instead of the default single CPU.
-
 ## Identifying nodes with a running CPU manager
 
 At this time, [Kubernetes doesn't label the


### PR DESCRIPTION
Revert changes made by PR #736.
PR https://github.com/kubevirt/community/pull/247 now proposes a different approach.