### PR TITLE
Move mazzystr to emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,7 +11,6 @@ filters:
       - jean-edouard
       - mhenriks
       - phoracek
-      - mazzystr
       - cwilkers
       - jobbler
       - aburdenthehand
@@ -26,13 +25,13 @@ filters:
       - jean-edouard
       - mhenriks
       - phoracek
-      - mazzystr
       - cwilkers
     emeritus_approvers:
       - ashleyschuett
       - codificat
       - hroyrh
       - danielBelenky
+      - mazzystr
 
   "^docs/.*":
     labels:


### PR DESCRIPTION
@mazzystr has left the project a while ago, so we are moving him to emeritus.

/cc @aburdenthehand 