### PR TITLE
VM rollout strategy

### DIFF
--- a/docs/operations/.pages
+++ b/docs/operations/.pages
@@ -34,4 +34,5 @@ nav:
   - feature_gate_status_on_Arm64.md
   - cpu_hotplug.md
   - memory_hotplug.md
+  - vm_rollout_strategies.md
   - hook-sidecar.md

--- a/docs/operations/cpu_hotplug.md
+++ b/docs/operations/cpu_hotplug.md
@@ -38,23 +38,31 @@ spec:
     - LiveMigrate
 ```
 
-### Enable in VM spec
-The VM object should look like this:
+### Configure the VM rollout strategy
+Hotplug requires a VM rollout strategy of `LiveUpdate`, so that the changes made to the VM object propagate to the VMI without a restart.
+This is also done in the KubeVirt CR configuration:
+
 ```yaml
 apiVersion: kubevirt.io/v1
-kind: VirtualMachine
+kind: KubeVirt
 spec:
-  liveUpdateFeatures:
-    cpu: {}
+  configuration:
+    vmRolloutStrategy: "LiveUpdate"
 ```
-Specifying the `cpu.maxSockets` value is optional. If you leave it unset, it will default to 4 times the `sockets` value.
 
-**NOTE:** In order for these changes to take effect the VM needs to be rebooted.
+More information can be found on the [VM Rollout Strategies](./vm_rollout_strategies.md) page
 
-### [OPTIONAL] Set maximum sockets
-You can explicitly set the maximum amount of sockets in two ways - VM level or Cluster level
+### [OPTIONAL] Set maximum sockets or hotplug ratio
+You can explicitly set the maximum amount of sockets in three ways:
 
-<table>
+1. with a value VM level
+2. with a value at the cluster level
+3, with a ratio at the cluster level (`maxSockets = ratio * sockets`).
+
+Note: the third way (cluster-level ratio) will also affect other quantitative hotplug resources like memory.
+
+
+<table style="width: 100% ; display: inline-table">
 <tr>
 <th>
 <p>
@@ -63,7 +71,12 @@ VM level
 </th> 
 <th>
 <p>
-Cluster level (Kubevirt CR)
+Cluster level value
+</p>
+</th>
+<th>
+<p>
+Cluster level ratio
 </p>
 </th>
 </tr>
@@ -74,9 +87,11 @@ Cluster level (Kubevirt CR)
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 spec:
-  liveUpdateFeatures:
-    cpu:
-      maxSockets: 8
+  template:
+    spec:
+      domain:
+        cpu:
+          maxSockets: 8
 ```
 </td>
 <td>
@@ -91,10 +106,23 @@ spec:
 ```
 
 </td>
+
+<td>
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+spec:
+  configuration:
+    liveUpdateConfiguration:
+      maxHotplugRatio: 4
+```
+
+</td>
 </tr>
 </table>
 
-The VM-level configuration will take precendence over the cluster-wide configuration.
+The VM-level configuration will take precedence over the cluster-wide configuration.
 
 
 

--- a/docs/operations/vm_rollout_strategies.md
+++ b/docs/operations/vm_rollout_strategies.md
@@ -1,0 +1,65 @@
+# VM Rollout Strategies
+
+In KubeVirt, the VM rollout strategy defines how changes to a VM object affect a running guest.  
+In other words, it defines when and how changes to a VM object get propagated to its corresponding VMI object.
+
+There are currently 2 rollout strategies: `LiveUpdate` and `Stage`.
+Only 1 can be specified and the default is `Stage`.
+
+## Feature Gate
+
+As long as the `VMLiveUpdateFeatures` is not enabled, the VM Rollout Strategy is ignored and defaults to "Stage".
+The feature gate is set in the KubeVirt custom resource (CR) like that:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+spec:
+  configuration:
+    developerConfiguration:
+      featureGates:
+        - VMLiveUpdateFeatures
+```
+
+## LiveUpdate
+
+The `LiveUpdate` VM rollout strategy tries to propagate VM object changes to running VMIs as soon as possible.  
+For example, changing the number of CPU sockets will trigger a [CPU hotplug](./cpu_hotplug.md).
+
+Enable the `LiveUpdate` VM rollout strategy in the KubeVirt CR:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+spec:
+  configuration:
+    vmRolloutStrategy: "LiveUpdate"
+```
+
+## Stage
+
+The `Stage` VM rollout strategy stages every change made to the VM object until its next reboot.  
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+spec:
+  configuration:
+    vmRolloutStrategy: "Stage"
+```
+
+## RestartRequired condition
+
+Any change made to a VM object when the rollout strategy is `Stage` will trigger the `RestartRequired` VM condition.  
+When the rollout strategy is `LiveUpdate`, only non-propagatable changes will trigger the condition.
+
+Once the `RestartRequired` condition is set on a VM object, no further changes can be propagated, even if the strategy is set to `LiveUpdate`.  
+Changes will become effective on next reboot, and the condition will be removed.
+
+## Limitations
+
+The current implementation has the following limitations:
+
+- Once the `RestartRequired` condition is set, the only way to get rid of it is to restart the VM. In the future, we plan on implementing a way to get rid of it by reverting the VM template spec to its last non-RestartRequired state.
+- Cluster defaults are excluded from this logic. It means that changing a cluster-wide setting that impacts VM specs will not be live-updated, regardless of the rollout strategy.
+- The `RestartRequired` condition comes with a message stating what kind of change triggered the condition (CPU/memory/other). That message pertains only to the first change that triggered the condition. Additional changes that would usually trigger the condition will just get staged and no additional `RestartRequired` condition will be added.


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating CPU hotplug documentation and add a pages about VM rollout strategies

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
