### PR TITLE
Accessing Virtual Machines: Switch to cloudInitNoCloud

### DIFF
--- a/docs/virtual_machines/accessing_virtual_machines.md
+++ b/docs/virtual_machines/accessing_virtual_machines.md
@@ -99,7 +99,7 @@ kubectl create secret generic my-pub-key --from-file=key1=id_rsa.pub
 ```
 
 The `Secret` containing the public key is then assigned to a virtual machine
-using the access credentials API with the `configDrive` propagation method.
+using the access credentials API with the `noCloud` propagation method.
 
 KubeVirt injects the SSH public key into the virtual machine by using the
 generated cloud-init metadata instead of the user data. This separates
@@ -108,7 +108,7 @@ the application user data and user credentials.
 > Note: The cloud-init `userData` is not touched.
 
 ```shell
-# Create a VM referencing the Secret using propagation method configDrive
+# Create a VM referencing the Secret using propagation method noCloud
 kubectl create -f - <<EOF
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
@@ -138,12 +138,12 @@ spec:
             secret:
               secretName: my-pub-key
           propagationMethod:
-            configDrive: {}
+            noCloud: {}
       volumes:
       - containerDisk:
           image: quay.io/containerdisks/fedora:latest
         name: containerdisk
-      - cloudInitConfigDrive:
+      - cloudInitNoCloud:
           userData: |-
             #cloud-config
             password: fedora
@@ -226,7 +226,7 @@ spec:
       - containerDisk:
           image: quay.io/containerdisks/fedora:latest
         name: containerdisk
-      - cloudInitConfigDrive:
+      - cloudInitNoCloud:
           userData: |-
             #cloud-config
             password: fedora


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Replace instances of cloudInitConfigDrive / configDrive with
cloudInitNoCloud / noCloud, since cloud-init NoCloud is the preferred
way to deliver cloud-init configuration data and it is now supported
by the access credentials api.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
