### PR TITLE
instancetypes: Document inferFromVolumeFailurePolicy

### DIFF
--- a/docs/virtual_machines/creating_vms.md
+++ b/docs/virtual_machines/creating_vms.md
@@ -1,8 +1,10 @@
 # Creating VirtualMachines
 
 The virtctl sub command `create vm` allows easy creation of VirtualMachine
-manifests from the command line. It
-leverages [instance types and preferences](./instancetypes.md)
+manifests from the command line. It leverages
+[instance types and preferences](./instancetypes.md) and inference by
+default (see
+[Specifying or inferring instance types and preferences](#specifying-or-inferring-instance-types-and-preferences))
 and provides several flags to control details of the created virtual machine.
 
 For example there are flags to specify the name or run strategy of a
@@ -123,13 +125,21 @@ virtctl create vm \
 If a prefix was not supplied the cluster scoped resources will be used by
 default.
 
-To
+To explicitly
 infer [instance types and/or preferences](./instancetypes.md#inferFromVolume)
 from the volume used to boot the virtual machine add the following flags:
 
 ```shell
 virtctl create vm --infer-instancetype --infer-preference
 ```
+
+The implicit default is to always try inferring an instancetype and
+preference from the boot volume. This feature makes use of the
+`IgnoreInferFromVolumeFailure` policy, which suppresses failures on inference
+of instancetypes and preferences. If one of the above switches was provided
+explicitly, then the `RejectInferFromVolumeFailure` policy is used instead.
+This way users are made aware of potential issues during the virtual machine
+creation.
 
 ## Boot order of added volumes
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Document the behavior of inferFromVolumeFailurePolicy and the inference by default in virtctl create vm.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
