### PR TITLE
Drop 'Enabling cpu compatibility enforcement'

### DIFF
--- a/docs/virtual_machines/virtual_hardware.md
+++ b/docs/virtual_machines/virtual_hardware.md
@@ -136,17 +136,11 @@ spec:
         claimName: myclaim
 ```
 
-#### Enabling cpu compatibility enforcement
-
-To enable the CPU compatibility enforcement, the `CPUNodeDiscovery`
-[feature gates](../operations/activating_feature_gates.md#how-to-activate-a-feature-gate)
-must be enabled in the KubeVirt CR.
-
-This feature-gate allows kubevirt to take VM cpu model and cpu features
-and create node selectors from them. With these node selectors, VM can
-be scheduled on the node which can support VM cpu model and features.
-
 #### Labeling nodes with cpu models and cpu features
+
+KubeVirt can create node selectors based on VM cpu models and features. With
+these node selectors, VMs will be scheduled on the nodes that support the matching
+VM cpu model and features.
 
 To properly label the node, user can use Kubevirt Node-labeller, which creates all 
 necessary labels or create node labels by himself.
@@ -154,8 +148,6 @@ necessary labels or create node labels by himself.
 Kubevirt node-labeller creates 3 types of labels: cpu models, cpu features and kvm info.
 It uses libvirt to get all supported cpu models and cpu
 features on host and then Node-labeller creates labels from cpu models. 
-Kubevirt can then schedule VM on node which has support for VM cpu model and
-features.
 
 Node-labeller supports obsolete list of cpu models and minimal baseline
 cpu model for features. Both features can be set via KubeVirt CR:


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The corresponding feature gate `CPUNodeDiscovery` is now enabled by default, hence the section is not needed anymore.

https://github.com/kubevirt/kubevirt/pull/7728

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
