### PR TITLE
kubevirt #11083 fix: broken formatting (and some editing)

### DIFF
--- a/docs/operations/mediated_devices_configuration.md
+++ b/docs/operations/mediated_devices_configuration.md
@@ -1,13 +1,13 @@
 # Mediated devices and virtual GPUs
+## Configuring mediated devices and virtual GPUs
 
 KubeVirt aims to facilitate the configuration of mediated devices on large clusters.
-The new `mediatedDevicesConfiguration` API in KubeVirt CR allows administrators to
-create or remove mediated devices in a declarative way, by providing a list of the desired mediated devices types  that they expect to be configured in the cluster.
+Administrators can use the `mediatedDevicesConfiguration` API in the KubeVirt CR to
+create or remove mediated devices in a declarative way, by providing a list of the desired mediated device types that they expect to be configured in the cluster.
 
-It would also be possible to provide a more specific configuration that targets a specific node or a group of nodes directly.
-This can be achieved by using the `nodeMediatedDeviceTypes`, however, it must be used in a combination with `mediatedDevicesTypes`, to override the global
-configuration set in `mediatedDevicesTypes` section. Therefore, using `nodeMediatedDeviceTypes` without the `mediatedDevicesTypes` section is not supported.
-
+You can also include the `nodeMediatedDeviceTypes` option to provide a more specific configuration that targets a specific node or a group of nodes directly with a node selector.
+The `nodeMediatedDeviceTypes` option must be used in combination with `mediatedDevicesTypes`
+in order to override the global configuration set in the `mediatedDevicesTypes` section.
 
 KubeVirt will use the provided configuration to automatically create the relevant mdev/vGPU devices on nodes that can support it.
 
@@ -16,114 +16,130 @@ The maximum amount of instances of the selected mdev type will be configured per
 
 > Note: Some vendors, such as NVIDIA, require a driver to be installed on the nodes to provide mediated devices, including vGPUs.
 
-Here's an example of a configuration that can be provided to KubeVirt CR:
+Example snippet of a KubeVirt CR configuration that includes both `nodeMediatedDeviceTypes` and `mediatedDevicesTypes`:
 ```yaml
-spec:  
-  configuration:  
-     mediatedDevicesConfiguration:  
-       mediatedDevicesTypes:  
-       - nvidia-222  
-       - nvidia-228  
-       nodeMediatedDeviceTypes:  
-       - nodeSelector:  
-           kubernetes.io/hostname: nodeName  
-         mediatedDevicesTypes:  
-         - nvidia-234
+spec:
+  configuration:
+    mediatedDevicesConfiguration:
+      mediatedDevicesTypes:
+      - nvidia-222
+      - nvidia-228
+      nodeMediatedDeviceTypes:
+      - nodeSelector:
+          kubernetes.io/hostname: nodeName
+        mediatedDevicesTypes:
+        - nvidia-234
 ```
 
 ## Configuration scenarios
-### Large cluster with multiple cards on each node
+### Example: Large cluster with multiple cards on each node
 
-On nodes with multiple cards that can support similar vGPU types, the relevant desired types will be created in a round-robin manner.  
+On nodes with multiple cards that can support similar vGPU types, the relevant desired types will be created in a round-robin manner.
 
-#### For example, considering the following configuration:  
+For example, considering the following KubeVirt CR configuration:
+
+```yaml
+spec:
+  configuration:
+    mediatedDevicesConfiguration:
+      mediatedDevicesTypes:
+      - nvidia-222
+      - nvidia-228
+      - nvidia-105
+      - nvidia-108
 ```
-mediatedDevicesConfiguration:
-  mediatedDevicesTypes:
-  - nvidia-222
-  - nvidia-228
-  - nvidia-105
-  - nvidia-108
-```
-* Nodes with 2 Tesla T4 cards
-  * Each card can support multiple types:
+
+This cluster has nodes with two different PCIe cards:
+
+1. Nodes with 3 Tesla T4 cards, where each card can support multiple devices types:
     * nvidia-222
     * nvidia-223
     * nvidia-228
     * ...
-* Nodes with 2 Tesla V100 cards
-  * Each card can support multiple types:
+
+2. Nodes with 2 Tesla V100 cards, where each card can support multiple device types:
     * nvidia-105
-    * ...
     * nvidia-108
     * nvidia-217
     * nvidia-299
     * ...
 
-KubeVirt will create the following devices:
+KubeVirt will then create the following devices:
 
-* Nodes with 3 Tesla T4 cards will be configured with
-  * 16 vGPUs of type nvidia-222 on card 1
-  * 2 vGPUs of type nvidia-228 on card 2
-  * 16 vGPUs of type nvidia-222 on card 3
-* Nodes with 2 Tesla V100 cards will be configured with
-  * 16 vGPUs of type nvidia-105 on card 1
-  * 2 vGPUs of type nvidia-108 on card 2
+1. Nodes with 3 Tesla T4 cards will be configured with:
+    * 16 vGPUs of type nvidia-222 on card 1
+    * 2 vGPUs of type nvidia-228 on card 2
+    * 16 vGPUs of type nvidia-222 on card 3
+2. Nodes with 2 Tesla V100 cards will be configured with:
+    * 16 vGPUs of type nvidia-105 on card 1
+    * 2 vGPUs of type nvidia-108 on card 2
 
 
-### Single card on a node, multiple desired vGPU types are supported
+### Example: Single card on a node, multiple desired vGPU types are supported
 
-The first supported type from the list will be configured  
-##### For example, consider the following list of desired types, where nvidia-223 and nvidia-224 are supported:
+When nodes only have a single card, the first supported type from the list will be configured.
+
+For example, consider the following list of desired types, where nvidia-223 and nvidia-224 are supported:
+
+```yaml
+spec:
+  configuration:
+    mediatedDevicesConfiguration:
+      mediatedDevicesTypes:
+      - nvidia-223
+      - nvidia-224
 ```
-mediatedDevicesConfiguration:
-  mediatedDevicesTypes:  
-  - nvidia-22  
-  - nvidia-223  
-  - nvidia-224
-```
-In this case, nvidia-223 will be configured on the node.
+In this case, nvidia-223 will be configured on the node because it is the first supported type in the list.
 
-### Overriding configuration on a specifc node
+## Overriding configuration on a specifc node
 
-`nodeMediatedDeviceTypes` needs to be used along with `mediatedDevicesTypes`, to override the global config brought in by, `mediatedDevicesTypes`.
+To override the global configuration set by `mediatedDevicesTypes`, include the `nodeMediatedDeviceTypes` option, specifying the node selector and the `mediatedDevicesTypes` that you want to override for that node.
 
-#### For example, considering the following configuration:  
+### Example: Overriding the configuration for a specific node in a large cluster with multiple cards on each node
+
+In this example, the KubeVirt CR includes the `nodeMediatedDeviceTypes` option to override the global configuration specifically for node 2, which will only use the nvidia-234 type.
+
+```yaml
+spec:
+  configuration:
+    mediatedDevicesConfiguration:
+      mediatedDevicesTypes:
+      - nvidia-230
+      - nvidia-223
+      - nvidia-224
+    nodeMediatedDeviceTypes:
+    - nodeSelector:
+        kubernetes.io/hostname: node2  
+      mediatedDevicesTypes:
+      - nvidia-234
 ```
-mediatedDevicesConfiguration:
-  mediatedDevicesTypes:  
-  - nvidia-230
-  - nvidia-223  
-  - nvidia-224
-  nodeMediatedDeviceTypes:  
-  - nodeSelector:  
-      kubernetes.io/hostname: node2  
-    mediatedDevicesTypes:  
-    - nvidia-234
-```
-* Two nodes has 2 Tesla T4 cards
-  * Each card can support a long list of types:
+
+The cluster has two nodes that both have 3 Tesla T4 cards.
+
+* Each card can support a long list of types, including:
     * nvidia-222
     * nvidia-223
     * nvidia-224
     * nvidia-230
     * ...
 
-KubeVirt will create the following devices:
-* Node 1
-  * type nvidia-230 on card 1
-  * type nvidia-223 on card 2
-* Node 2
-  * type nvidia-234 on card 1 and card 2
+KubeVirt will then create the following devices:
 
+1. Node 1
+    * type nvidia-230 on card 1
+    * type nvidia-223 on card 2
+2. Node 2
+    * type nvidia-234 on card 1 and card 2
 
-### Updating and Removing vGPU types
+Node 1 has been configured in a round-robin manner based on the global configuration but node 2 only uses the nvidia-234 that was specified for it.
 
-Changes made to the mediatedDevicesTypes section of the KubeVirt CR will trigger a re-evaluation of the configured mdevs/vGPU types on the cluster nodes.
+## Updating and Removing vGPU types
 
-Any change to the node labels that match the nodeMediatedDeviceTypes nodeSelector in the KubeVirt CR will trigger a similar re-evaluation.
+Changes made to the `mediatedDevicesTypes` section of the KubeVirt CR will trigger a re-evaluation of the configured mdevs/vGPU types on the cluster nodes.
+
+Any change to the node labels that match the `nodeMediatedDeviceTypes` nodeSelector in the KubeVirt CR will trigger a similar re-evaluation.
 
 Consequently, mediated devices will be reconfigured or entirely removed based on the updated configuration.
 
 ## Assigning vGPU/MDEV to a Virtual Machine
-See the [Host Devices Assignment](<../virtual_machines/host-devices.md>) to learn how to consume the newly created mediated devices/vGPUs
+See the [Host Devices Assignment](<../virtual_machines/host-devices.md>) to learn how to consume the newly created mediated devices/vGPUs.


### PR DESCRIPTION
**What this PR does / why we need it**:
Issue [#11083](https://github.com/kubevirt/kubevirt/issues/11083) in the kubevirt/kubevirt raised some broken formatting, making the examples difficult to understand. 

While fixing these, I reformatted some of the titles which weren't so optimal with the new ToC. I also did some unrequested editing that started with removing some double spaces and ended with some rewrites and adding some additional context to the examples. Finally, I've added yaml tags to the blocks and added slightly more context to the KubeVirt CR snippets used so that they are easier to differentiate from the lists of device types. 

Direct link to build: https://deploy-preview-763--kubevirt-user-guide.netlify.app/operations/mediated_devices_configuration/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [#11083](https://github.com/kubevirt/kubevirt/issues/11083) in the kubevirt/kubevirt 

**Special notes for your reviewer**:

@vladikr - my apologies for making this a bigger change than initially suggested. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
