### PR TITLE
networking: Update Multus example to use bridge CNI

### DIFF
--- a/docs/virtual_machines/interfaces_and_networks.md
+++ b/docs/virtual_machines/interfaces_and_networks.md
@@ -77,10 +77,10 @@ It is also possible to connect VMIs to secondary networks using
 is installed across your cluster and a corresponding
 `NetworkAttachmentDefinition` CRD was created.
 
-The following example defines a network which uses the [ovs-cni
-plugin](https://github.com/kubevirt/ovs-cni), which will connect the VMI
-to Open vSwitch's bridge `br1` and VLAN 100. Other CNI plugins such as
-ptp, bridge, or Flannel might be used as well. For their
+The following example defines a network which uses the [bridge CNI
+plugin](https://www.cni.dev/plugins/current/main/bridge/), which will connect the VMI
+to Linux bridge `br1`. Other CNI plugins such as
+ptp, ovs-cni, or Flannel might be used as well. For their
 installation and usage refer to the respective project documentation.
 
 First the `NetworkAttachmentDefinition` needs to be created. That is
@@ -91,13 +91,14 @@ definition.
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
-  name: ovs-vlan-100
+  name: bridge-test
 spec:
   config: '{
       "cniVersion": "0.3.1",
-      "type": "ovs",
+      "name": "bridge-test",
+      "type": "bridge",
       "bridge": "br1",
-      "vlan": 100
+      "disableContainerInterface": true
     }'
 ```
 

--- a/docs/virtual_machines/interfaces_and_networks.md
+++ b/docs/virtual_machines/interfaces_and_networks.md
@@ -1100,8 +1100,9 @@ spec:
   config: '{
             "cniVersion": "0.3.1",
             "name": "br-spoof-check",
-            "type": "cnv-bridge",
+            "type": "bridge",
             "bridge": "br10",
+            "disableContainerInterface": true,
             "macspoofchk": true
         }'
 ```

--- a/docs/virtual_machines/interfaces_and_networks.md
+++ b/docs/virtual_machines/interfaces_and_networks.md
@@ -1080,17 +1080,13 @@ There are two known CNI plugins that support mac-spoof-check:
 
 - [sriov-cni](https://github.com/openshift/sriov-cni):
   Through the `spoofchk` parameter .
-- cnv-bridge: Through the `macspoofchk`.
-
-> **Note:** `cnv-bridge` is provided by
-  [CNAO](https://github.com/kubevirt/cluster-network-addons-operator).
-  The [bridge-cni](https://github.com/containernetworking/plugins) is planned
-  to support the `macspoofchk` options as well.
+- [bridge-cni](https://www.cni.dev/plugins/current/main/bridge/):
+  Through the `macspoofchk` parameter.
 
 The configuration is to be done on the  NetworkAttachmentDefinition by the
 operator and any interface that refers to it, will have this feature enabled.
 
-Below is an example of using the `cnv-bridge` CNI with `macspoofchk` enabled:
+Below is an example of using the `bridge` CNI with `macspoofchk` enabled:
 ```yaml
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
@@ -1120,5 +1116,5 @@ networks:
 
 #### Limitations
 
-- The `cnv-bridge` CNI supports mac-spoof-check through nftables, therefore
+- The `bridge` CNI supports mac-spoof-check through nftables, therefore
 the node must support nftables and have the `nft` binary deployed.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update the 'Interface And Networking' docs, Multus example to use bridge CNI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
