### PR TITLE
Add migration API to the network binding plugin docs

### DIFF
--- a/docs/virtual_machines/net_binding_plugins/passt.md
+++ b/docs/virtual_machines/net_binding_plugins/passt.md
@@ -20,7 +20,7 @@ Its main benefits are:
 ### Functionality support
 | Functionality                                  | Support |
 |------------------------------------------------|---------|
-| Migration support                              | No      |
+| Migration support                              | Yes     |
 | Service Mesh support                           | Yes     |
 | Pod IP in guest                                | Yes     |
 | Custom CIDR in guest                           | No      |
@@ -143,7 +143,10 @@ kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "pat
             "binding": {
                 "passt": {
                     "networkAttachmentDefinition": "default/netbindingpasst",
-                    "sidecarImage": "quay.io/kubevirt/network-passt-binding:20231205_29a16d5c9"
+                    "sidecarImage": "quay.io/kubevirt/network-passt-binding:20231205_29a16d5c9",
+                    "migration": {
+                        "method": "link-refresh"
+                    }
                 }
             }
         }}]'

--- a/docs/virtual_machines/network_binding_plugins.md
+++ b/docs/virtual_machines/network_binding_plugins.md
@@ -144,6 +144,7 @@ The following (optional) parameters are currently supported:
 - [networkAttachmentDefinition](#networkattachmentdefinition)
 - [sidecarImage](#sidecarimage)
 - [domainAttachmentType](#domainattachmenttype)
+- [migration](#migration)
 
 #### networkAttachmentDefinition
 From: v1.1.0
@@ -178,6 +179,14 @@ When both the `domainAttachmentType` and `sidecarImage` are specified,
 the domain will first be configured according to the `domainAttachmentType`
 and then the `sidecarImage` may modify it.
 
+#### migration
+From: v1.2.0
+
+Specify whether the network binding plugin supports migration.
+It is possible to specify a migration method.
+Supported migration method types:
+- `link-refresh` (from v1.2.0): after migration, the guest nic will be deactivated and then activated again.
+   It can be useful to renew the DHCP lease.
 
 > **Note**: In some deployments the Kubevirt CR is controlled by an external
 > controller (e.g. [HCO](https://github.com/kubevirt/hyperconverged-cluster-operator)).
@@ -191,6 +200,9 @@ kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "pat
                 "passt": {
                     "networkAttachmentDefinition": "default/netbindingpasst",
                     "sidecarImage": "quay.io/kubevirt/network-passt-binding:20231205_29a16d5c9"
+                    "migration": {
+                        "method": "link-refresh"
+                    }
                 }
             }
         }}]'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pullrequest-as-draft
3. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add migration API to the network binding plugin docs.
Also update the passt docs to specify it supports migration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
