### PR TITLE
SR-IOV doc fixes

### DIFF
--- a/docs/virtual_machines/interfaces_and_networks.md
+++ b/docs/virtual_machines/interfaces_and_networks.md
@@ -785,19 +785,19 @@ device, using the
 interface, to maintain high networking performance.
 
 #### How to expose SR-IOV VFs to KubeVirt
-To simplify procedure, please use [OpenShift SR-IOV
-operator](https://github.com/openshift/sriov-network-operator) to deploy
+To simplify procedure, please use [SR-IOV network
+operator](https://github.com/k8snetworkplumbingwg/sriov-network-operator) to deploy
 and configure SR-IOV components in your cluster. On how to use the
 operator, please refer to [their respective
-documentation](https://github.com/openshift/sriov-network-operator/blob/master/doc/quickstart.md).
+documentation](https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/doc/quickstart.md).
 
 > **Note:** KubeVirt relies on VFIO userspace driver to pass PCI devices
 > into VMI guest. Because of that, when configuring SR-IOV operator
 > policies, make sure you define a pool of VF resources that uses
-> `driver: vfio`.
+> `deviceType: vfio-pci`.
 
 Once the operator is deployed, an [SriovNetworkNodePolicy
-](https://github.com/openshift/sriov-network-operator#sriovnetworknodeconfigpolicy)
+](https://github.com/k8snetworkplumbingwg/sriov-network-operator#sriovnetworknodepolicy)
 must be provisioned, in which the list of SR-IOV devices to expose (with
 respective configurations) is defined.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

SR-IOV doc fixes
    
- fix reference to vfio-pci devicetype: `driver: vfio` is not valid (you will see `driver: vfio-pci ` in the `SriovNetworkNodeState` however in the policy it is `deviceType: vfio-pci`)
- sriov-network-operator - swap `openshift` for `k8snetworkplumbingwg` ([k8snetworkplumbingwg](https://github.com/k8snetworkplumbingwg/sriov-network-operator) is upstream from [openshift](https://github.com/openshift/sriov-network-operator) repo now and should be considered the authoritative source)
  
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
