### PR TITLE
virtctl: use the stable version for virtctl

### DIFF
--- a/docs/operations/virtctl_client_tool.md
+++ b/docs/operations/virtctl_client_tool.md
@@ -28,7 +28,7 @@ There are two ways to get it:
 Example:
 
 ```
-export VERSION=v0.41.0
+export VERSION==$(curl https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)
 wget https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/virtctl-${VERSION}-linux-amd64
 ```
 


### PR DESCRIPTION
The current version reported in the guide is quite old and the users should try to install the latest version of virtctl when possible.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update the documentation to fetch the latest virtctl version

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
