### PR TITLE
fix cdrom readonly field

### DIFF
--- a/docs/storage/disks_and_volumes.md
+++ b/docs/storage/disks_and_volumes.md
@@ -157,7 +157,7 @@ spec:
         # This makes it a cdrom
         cdrom:
           # This makes the cdrom writeable
-          readOnly: false
+          readonly: false
           # This makes the cdrom be exposed as SATA device
           bus: sata
   volumes:


### PR DESCRIPTION
**What this PR does / why we need it**:

cdrom readonly field is `readonly` not `readOnly` - see: https://github.com/kubevirt/kubevirt/blob/6c25e0e56eef200423811486523d9863e3f9ea79/staging/src/kubevirt.io/api/core/v1/schema.go#L702