### PR TITLE
volumes: move the disk expansion documentation

### DIFF
--- a/docs/virtual_machines/disks_and_volumes.md
+++ b/docs/virtual_machines/disks_and_volumes.md
@@ -463,6 +463,26 @@ spec:
       storage: 1Gi
 ```
 
+#### disk expansion
+
+For some storage methods, Kubernetes may support expanding storage in-use (allowVolumeExpansion feature).
+KubeVirt can respond to it by making the additional storage available for the virtual machines.
+This feature is currently off by default, and requires enabling a feature gate.
+To enable it, add the ExpandDisks feature gate in the kubevirt object:
+
+```yaml
+spec:
+  configuration:
+    developerConfiguration:
+      featureGates:
+      - ExpandDisks
+```
+
+Enabling this feature does two things:
+- Notify the virtual machine about size changes
+- If the disk is a Filesystem PVC, the matching file is expanded
+  to the remaining size (while reserving some space for file system overhead).
+
 #### dataVolume
 
 DataVolumes are a way to automate importing virtual machine disks onto


### PR DESCRIPTION
The disk expansion feature is documented in [kubevirt/kubevirt/docs/disk-expansion](https://github.com/kubevirt/kubevirt/blob/main/docs/disk-expansion.md) , but it is missing in the user-guide.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Document disk expansion in the user-guide
```
