### PR TITLE
volumes: move the discard passthrough documentation

### DIFF
--- a/docs/virtual_machines/disks_and_volumes.md
+++ b/docs/virtual_machines/disks_and_volumes.md
@@ -412,6 +412,57 @@ spec:
         claimName: mypvc
 ```
 
+#### Thick and thin volume provisioning
+
+Sparsification can make a disk thin-provisioned, in other words it allows to
+convert the freed space within the disk image into free space back on the host.
+The [fstrim](https://man7.org/linux/man-pages/man8/fstrim.8.html#:~:text=fstrim%20is%20used%20on%20a,unused%20blocks%20in%20the%20filesystem)
+utility can be used on a mounted filesystem to discard the blocks not used by the filesystem.
+In order to be able to sparsify a disk inside the guest, the disk needs to be configured in the
+[libvirt xml](https://libvirt.org/formatdomain.html) with the option `discard=unmap`.
+In KubeVirt, every disk is passed as default with this option enabled. It is
+possible to check if the trim configuration is supported in the guest by
+running`lsblk -D`, and check the discard options supported on every disk.
+
+Example:
+```bash
+$ lsblk -D
+NAME   DISC-ALN DISC-GRAN DISC-MAX DISC-ZERO
+loop0         0        4K       4G         0
+loop1         0       64K       4M         0
+sr0           0        0B       0B         0
+rbd0          0       64K       4M         0
+vda         512      512B       2G         0
+└─vda1        0      512B       2G         0
+```
+
+However, in certain cases like preallocaton or when the disk is thick
+provisioned, the option needs to be disabled. The disk's PVC has to be marked
+with an annotation that contains `/storage.preallocation` or
+`/storage.thick-provisioned`, and set to true. If the volume is preprovisioned
+using [CDI](https://github.com/kubevirt/containerized-data-importer) and the
+[preallocation](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/preallocation.md)
+is enabled, then the PVC is automatically annotated with: `cdi.kubevirt.io/storage.preallocation: true`
+and the discard passthrough option is disabled.
+
+Example of a PVC definition with the annotation to disable discard passthrough:
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc
+  annotations:
+    user.custom.annotation/storage.thick-provisioned: "true"
+spec:
+  storageClassName: local
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 1Gi
+```
+
 #### dataVolume
 
 DataVolumes are a way to automate importing virtual machine disks onto


### PR DESCRIPTION
The discard passthrough feature is documented in [kubevirt/kubevirt/docs/discard-passthrough.md](https://github.com/kubevirt/kubevirt/blob/main/docs/discard-passthrough.md), but it is missing in the user-guide.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Document discard passthrough in the user-guide
```
