### PR TITLE
image field in hook sidecar annotation is optional

### DIFF
--- a/docs/operations/hook-sidecar.md
+++ b/docs/operations/hook-sidecar.md
@@ -43,6 +43,8 @@ the CloudInitData (e.g `--cloud-init cloudInitJSON`). It outputs the modified Cl
 Shell or python scripts can be used as alternatives to the binary, by making them available at the expected location 
 (`/usr/bin/onDefineDomain` or `/usr/bin/preCloudInitIso` depending upon the hook).
 
+A prebuilt image named `sidecar-shim` capable of running Shell or Python scripts is shipped as part of KubeVirt releases.
+
 ## Go, Python, Shell - pick any one
 
 Although a binary doesn't strictly need to be generated from Go code, and a script doesn't strictly need to be one
@@ -64,6 +66,7 @@ annotations to make sure the script is run before the VMI creation. The flow wou
 
 1. Create a ConfigMap containing the shell or python script you want to run
 1. Create a VMI containing the annotation `hooks.kubevirt.io/hookSidecars` and mention the ConfigMap information in it.
+1. In this case a predefined image can be used to handle the communication with the main container.
 
 #### ConfigMap with shell script
 
@@ -135,7 +138,6 @@ annotations:
     [
         {
             "args": ["--version", "v1alpha2"],
-            "image": "registry:5000/kubevirt/sidecar-shim:devel",
             "configMap": {"name": "my-config-map", "key": "my_script.sh", "hookPath": "/usr/bin/onDefineDomain"}
         }
     ]
@@ -146,6 +148,8 @@ The `name` field indicates the name of the ConfigMap on the cluster which contai
 `key` field indicates the key in the ConfigMap which contains the script to be executed. Finally, `hookPath` indicates
 the path where you want the script to be mounted. It could be either of `/usr/bin/onDefineDomain` or
 `/usr/bin/preCloudInitIso` depending upon the hook you want to execute.
+An optional value can be specified with the `"image"` key if a custom image is needed, if omitted the default Sidecar-shim image built together with the other KubeVirt images will be used.
+The default Sidecar-shim image, if not override with a custom value, will also be updated as other images as for [Updating KubeVirt Workloads](./updating_and_deletion/#updating-kubevirt-workloads).
 
 ### Verify everything works
 


### PR DESCRIPTION
**What this PR does / why we need it**:
with https://github.com/kubevirt/kubevirt/pull/11272 image field becomes optional in the hook sidecar annotation since, if omitted, virt-controller will now use
a default sidecar-shim image built with other kubevirt images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #775 

**Special notes for your reviewer**:
No to retrieve the version of the hook sidecar shim version from kubevirt CR, the virt-controller can now autonomously handle it. 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [X] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
image field in hook sidecar annotation is optional
```
