### PR TITLE
Remove extra "=" on virtctl_client_tool user_guide

### DIFF
--- a/docs/operations/virtctl_client_tool.md
+++ b/docs/operations/virtctl_client_tool.md
@@ -28,7 +28,7 @@ There are two ways to get it:
 Example:
 
 ```
-export VERSION==$(curl https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)
+export VERSION=$(curl https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)
 wget https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/virtctl-${VERSION}-linux-amd64
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a typo on the virtctl Client Tool installation, this extra "=" is leading users to an error when trying to install virtctl.

```
galmeida@VAN-932852-LT0:~/kubevirt-gitops$ export VERSION==$(curl https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     7  100     7    0     0     89      0 --:--:-- --:--:-- --:--:--    89
galmeida@VAN-932852-LT0:~/kubevirt-gitops$ wget https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/virtctl-${VERSION}-linux-amd64
--2024-04-25 11:24:35--  https://github.com/kubevirt/kubevirt/releases/download/=v1.2.0/virtctl-=v1.2.0-linux-amd64
Resolving github.com (github.com)... 140.82.114.4
Connecting to github.com (github.com)|140.82.114.4|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2024-04-25 11:24:36 ERROR 404: Not Found.

galmeida@VAN-932852-LT0:~/kubevirt-gitops$ echo $VERSION
=v1.2.0
```

E.g. 
Expected --> v1.2.0
Actual result --> =v1.2.0

**Special notes for your reviewer**:
This is my first PR, sorry about any mistakes.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
