### PR TITLE
Fix typo: ymal ⇒ yaml

### DIFF
--- a/docs/debug_virt_stack/privileged-node-debugging.md
+++ b/docs/debug_virt_stack/privileged-node-debugging.md
@@ -7,7 +7,7 @@ With privileged pods, you may access devices in `/dev`, utilize host namespaces 
 A quick way to verify if you are allowed to create privileged pods is to create a sample pod with the `--dry-run=server` option, like:
 
 ```console
-$ kubectl apply -f debug-pod.ymal --dry-run=server
+$ kubectl apply -f debug-pod.yaml --dry-run=server
 ```
 
 # Build the container image


### PR DESCRIPTION
Fix a simple typo: ymal => yaml

```release-note
NONE
```
