### PR TITLE
Replace usage of DataVolume.spec.pvc with .storage

### DIFF
--- a/docs/storage/disks_and_volumes.md
+++ b/docs/storage/disks_and_volumes.md
@@ -582,9 +582,7 @@ spec:
   - metadata:
       name: alpine-dv
     spec:
-      pvc:
-        accessModes:
-        - ReadWriteOnce
+      storage:
         resources:
           requests:
             storage: 2Gi

--- a/docs/storage/hotplug_volumes.md
+++ b/docs/storage/hotplug_volumes.md
@@ -20,9 +20,7 @@ metadata:
 spec:
   source:
     blank: {}
-  pvc:
-    accessModes:
-      - ReadWriteOnce
+  storage:
     resources:
       requests:
         storage: 5Gi

--- a/docs/user_workloads/instancetypes.md
+++ b/docs/user_workloads/instancetypes.md
@@ -363,9 +363,7 @@ spec:
     - metadata:
         name: cirros-datavolume
       spec:
-        pvc:
-          accessModes:
-            - ReadWriteOnce
+        storage:
           resources:
             requests:
               storage: 1Gi
@@ -429,7 +427,7 @@ spec:
     - metadata:
         name: cirros-datavolume
       spec:
-        pvc:
+        storage:
           accessModes:
             - ReadWriteOnce
           resources:

--- a/docs/user_workloads/startup_scripts.md
+++ b/docs/user_workloads/startup_scripts.md
@@ -1134,12 +1134,7 @@ spec:
     - metadata:
         name: win10-template-windows-iso
       spec:
-        pvc:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 20Gi
+        storage: {}
         source:
           pvc:
             name: windows10-iso
@@ -1147,9 +1142,7 @@ spec:
     - metadata:
         name: win10-template
       spec:
-        pvc:
-          accessModes:
-            - ReadWriteOnce
+        storage:
           resources:
             requests:
               storage: 25Gi

--- a/docs/user_workloads/templates.md
+++ b/docs/user_workloads/templates.md
@@ -160,12 +160,9 @@ items:
       metadata:
         name: rheltinyvm
       spec:
-        pvc:
+        storage:
           accessModes:
           - ReadWriteMany
-          resources:
-            requests:
-              storage: 30Gi
         source:
           pvc:
             name: rhel
@@ -539,12 +536,9 @@ objects:
       metadata:
         name: ${NAME}
       spec:
-        pvc:
+        storage:
           accessModes:
             - ReadWriteMany
-          resources:
-            requests:
-              storage: 30Gi
         source:
           pvc:
             name: ${SRC_PVC_NAME}
@@ -764,9 +758,7 @@ spec:
   source:
     registry:
       url: "image_url"
-  pvc:
-    accessModes:
-      - ReadWriteOnce
+  storage:
     resources:
       requests:
         storage: 30Gi


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces DataVolume PVC target with the newer storage target.

This is the modern API we want users to be using. It also allows for skipping certain parameters due to better defaults.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
