### PR TITLE
operations, network: Declare network hotplug feature as Beta

### DIFF
--- a/docs/network/hotplug_interfaces.md
+++ b/docs/network/hotplug_interfaces.md
@@ -1,6 +1,8 @@
 # Hotplug Network Interfaces
 
-**Warning**: The feature is in alpha stage and its API may be changed in the future.
+Release:
+- v1.1.0: Alpha
+- v1.3.0: Beta
 
 KubeVirt supports hotplugging and unplugging network interfaces into a running Virtual Machine (VM). 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The network hotplug feature has been available since Kubevirt v1.1 as Alpha.
There have been no changes in the API since and the feedback from users has been positive.

Therefore, the feature is declared Beta towards v1.3 and should be proposed for GA towards v1.4.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
