### PR TITLE
node assignment: add paragraph about live updates

### DIFF
--- a/docs/compute/node_assignment.md
+++ b/docs/compute/node_assignment.md
@@ -166,3 +166,13 @@ spec:
 This annotation will cause, that the descheduler will be able to evict the VM's pod which can then be
 scheduled by scheduler on different nodes. A VirtualMachine will never restart or re-create a
 VirtualMachineInstance until the current instance of the VirtualMachineInstance is deleted from the cluster.
+
+## Live update
+
+When the [VM rollout strategy](../user_workloads/vm_rollout_strategies.md) is set to `LiveUpdate`, changes to a VM's
+node selector or affinities will dynamically propagate to the VMI (unless the `RestartRequired` condition is set).
+Changes to tolerations will not dynamically propagate, and will trigger a `RestartRequired` condition if changed on a
+running VM.
+
+Modifications of the node selector / affinities will only take effect on next [migration](live_migration.md), the change
+alone will not trigger one.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR documents the interractions between node selector / affinities and the LiveUpdate VM rollout strategy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
