### PR TITLE
passt: Add memory overhead

### DIFF
--- a/docs/network/net_binding_plugins/passt.md
+++ b/docs/network/net_binding_plugins/passt.md
@@ -146,6 +146,11 @@ kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "pat
                     "sidecarImage": "quay.io/kubevirt/network-passt-binding:20231205_29a16d5c9",
                     "migration": {
                         "method": "link-refresh"
+                    },
+                    "computeResourceOverhead": {
+                      "requests": {
+                        "memory": "500Mi",
+                      }
                     }
                 }
             }
@@ -155,6 +160,8 @@ kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "pat
 The NetworkAttachmentDefinition and sidecarImage values should correspond with the
 names used in the previous sections, [here](#passt-networkattachmentdefinition)
 and [here](#passt-sidecar-image).
+
+When using the plugin, additional memory overhead of `500Mi` will be requested for the compute container in the virt-launcher pod.
 
 ### VM Passt Network Interface
 Set the VM network interface binding name to reference the one defined in the


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Following PR https://github.com/kubevirt/kubevirt/pull/12235, it is now possible to specify memory overhead for the virt-launcher's compute container.

Instruct users of the passt binding plugin to register it with a memory overhead of 500Mi for the compute container.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
