### PR TITLE
Network binding plugins: Add compute resource overhead

### DIFF
--- a/docs/network/network_binding_plugins.md
+++ b/docs/network/network_binding_plugins.md
@@ -208,6 +208,43 @@ kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "pat
         }}]'
 ```
 
+#### Compute Resource Overhead
+From: v1.3.0
+
+Some plugins may need additional resources to be added to the compute container of the virt-launcher pod.
+
+It is possible to specify compute resource overhead that will be added to the `compute` container of virt-launcher pods
+derived from virtual machines using the plugin.
+
+> **Note**: At the moment, only memory overhead requests are supported.
+
+> **Note**: In some deployments the Kubevirt CR is controlled by an external
+> controller (e.g. [HCO](https://github.com/kubevirt/hyperconverged-cluster-operator)).
+> In such cases, make sure to configure the wrapper operator/controller so the
+> changes will get preserved.
+
+Example (the `passt` binding):
+```shell
+kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "path": "/spec/configuration/network",   "value": {
+            "binding": {
+                "passt": {
+                    "networkAttachmentDefinition": "default/netbindingpasst",
+                    "sidecarImage": "quay.io/kubevirt/network-passt-binding:20231205_29a16d5c9",
+                    "migration": {
+                        "method": "link-refresh"
+                    },
+                    "computeResourceOverhead": {
+                      "requests": {
+                        "memory": "500Mi",
+                      }
+                    }
+                }
+            }
+        }}]'
+```
+
+Every compute container in a virt-launcher pod derived from a VM using the passt network binding plugin, will have an additional `500Mi` memory overhead.
+
 ### VM Network Interface
 When configuring the VM/VMI network interface, the binding plugin name
 can be specified. If it exists in the Kubevirt CR, it will be used


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Following PR kubevirt/kubevirt#12235, it is now possible to specify memory overhead for the virt-launcher's compute container.

Add an explanation about the compute resource overhead in general, with a note that only memory overhead request is currently supported.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
