### PR TITLE
instancetypes: Add PreferredCPUTopology and SpreadOptions docs

### DIFF
--- a/docs/user_workloads/instancetypes.md
+++ b/docs/user_workloads/instancetypes.md
@@ -143,9 +143,59 @@ $ kubectl get vmis/example-preference-user-override -o json | jq .spec.domain.de
     "name": "cloudinitdisk"
   }
 ]
-
-
 ```
+
+### PreferredCPUTopology
+
+A preference can optionally include a `PreferredCPUTopology` that defines how the guest visible CPU topology of the `VirtualMachineInstance` is constructed from vCPUs supplied by an instance type.
+
+```yaml
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: example-preference-cpu-topology
+spec:
+  cpu:
+    preferredCPUTopology: cores
+```
+
+The allowed values for `PreferredCPUTopology` include:
+
+* `sockets` (default) - Provides vCPUs as sockets to the guest
+* `cores` - Provides vCPUs as cores to the guest
+* `threads` - Provides vCPUs as threads to the guest
+* `spread` - Spreads vCPUs across sockets and cores by default. See the following [SpreadOptions](#### SpreadOptions) section for more details.
+* `any` - Provides vCPUs as sockets to the guest, this is also used to express that any allocation of vCPUs is required by the preference. Useful when defining a preference that isn't used alongside an instance type.
+
+Note that support for the original `preferSockets`, `preferCores`, `preferThreads` and `preferSpread` values for `PreferredCPUTopology` is deprecated as of `v1.4.0` ahead of removal in a future release.
+
+#### SpreadOptions
+
+When `spread` is provided as the value of `PreferredCPUTopology` we can further customize how vCPUs are spread across the guest visible CPU topology using `SpreadOptions`:
+
+```yaml
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: example-preference-cpu-topology
+spec:
+  cpu:
+    preferredCPUTopology: spread
+    spreadOptions:
+      across: SocketsCoresThreads
+      ratio: 4
+```
+
+[`spreadOptions`](https://kubevirt.io/api-reference/main/definitions.html#_v1beta1_spreadoptions) provides the following configurables:
+
+* `across` - Defines how vCPUs should be spread across the guest visible CPU topology
+* `ratio`  - Defines the ratio at which vCPUs should be spread (defaults to 2)
+
+The allowed values for `across` include:
+
+* `SocketsCores` (default) - Spreads vCPUs across sockets and cores with a ratio of 1:N where N is the provided ratio.
+* `SocketsCoresThreads` - Spreads vCPUs across sockets, cores and threads with a ratio of 1:N:2 where N is the provided ratio.
+* `CoresThreads` - Spreads vCPUs across cores and threads with an enforced ratio of 1:2. (requires at least 2 vCPUs to be provided by an instance type)
 
 ## VirtualMachine
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
