### PR TITLE
Adding aburden as approver; removing jobbler as reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,27 +1,27 @@
 aliases:
   reviewers:
-  - vladikr
-  - fabiand
+  - aburdenthehand
   - AlonaKaplan
+  - cwilkers
   - dhiller
+  - fabiand
   - jean-edouard
   - mhenriks
   - phoracek
-  - cwilkers
-  - jobbler
-  - aburdenthehand
-  approvers:
-  - davidvossel
   - vladikr
+  approvers:
+  - aburdenthehand
+  - AlonaKaplan
+  - cwilkers
+  - davidvossel
+  - dhiller
+  - fabiand
+  - jean-edouard
+  - mhenriks
+  - phoracek
   - rmohr
   - stu-gott
-  - fabiand
-  - AlonaKaplan
-  - dhiller
-  - jean-edouard
-  - mhenriks
-  - phoracek
-  - cwilkers
+  - vladikr
 
   #
   # SIG Test


### PR DESCRIPTION
I would like to help out the user-guide repo by taking on the responsibility of an approver.

As per our [membership policy](https://github.com/kubevirt/community/blob/main/membership_policy.md#approver):
- have been a reviewer on the project for more than 3 months: #753 
- have [reviewed ~30 PRs](https://github.com/kubevirt/user-guide/pulls?q=is%3Apr+reviewed-by%3Aaburdenthehand+is%3Aclosed+) 
- have [authored 22 merged PRs](https://github.com/kubevirt/user-guide/pulls?q=is%3Apr+author%3Aaburdenthehand+is%3Aclosed)

@jean-edouard and @dhiller have agreed to sponsor me.

----

I've also removed @jobbler as a reviewer, as he has not been active in this capacity for over [12 months](https://github.com/kubevirt/user-guide/pulls?q=is%3Apr+reviewed-by%3Ajobbler+is%3Aclosed+): Thank you for all of your help in this repo over the years, John!

This PR also alphabetises the reviewer and approver owners (but not the others as these will eventually be automatically updated).
(Sorry, this does make it harder to assess the changes but it didn't seem worth a second PR)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
