### PR TITLE
Add a note about unsupported macOS

### DIFF
--- a/docs/cluster_admin/installation.md
+++ b/docs/cluster_admin/installation.md
@@ -17,6 +17,8 @@ A few requirements need to be met before you can begin:
 -   Kubernetes apiserver must have `--allow-privileged=true` in order to run KubeVirt's privileged DaemonSet.
 -   `kubectl` client utility
 
+Currently, macOS is not supported
+
 ### Container Runtime Support
 
 KubeVirt is currently supported on the following container runtimes:

--- a/docs/cluster_admin/virtual_machines_on_Arm64.md
+++ b/docs/cluster_admin/virtual_machines_on_Arm64.md
@@ -58,3 +58,7 @@ This class of devices is not verified on the Arm64 platform.
 ## Liveness and Readiness Probes
 
 `Watchdog` device is not supported on Arm64 platform.
+
+## Operating systems
+
+Currently, `macOS` runs on ARM architecture and this OS is not supported. However, you may try to run it using devContainers https://github.com/kubevirt/kubevirt/pull/11830


### PR DESCRIPTION
This PR clarify that macOS is unsupported for now. Changes will be noticeable at pages:
- [Installation Requirements](https://kubevirt.io/user-guide/cluster_admin/installation/#requirements)
- [Virtual Machines on Arm64](https://kubevirt.io/user-guide/cluster_admin/virtual_machines_on_Arm64/#virtual-machines-on-arm64)

Fixes #824 


**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
