### PR TITLE
installation: Add guide for using s390x developer builds

### DIFF
--- a/docs/cluster_admin/installation.md
+++ b/docs/cluster_admin/installation.md
@@ -225,6 +225,14 @@ ARM64 developer builds can be installed like this:
     $ kubectl apply -f https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${LATEST}/kubevirt-operator-arm64.yaml
     $ kubectl apply -f https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${LATEST}/kubevirt-cr-arm64.yaml
 
+### s390x developer builds
+
+s390x developer builds can be installed like this:
+
+    $ LATEST=$(curl -L https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest-s390x)
+    $ kubectl apply -f https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${LATEST}/kubevirt-operator-s390x.yaml
+    $ kubectl apply -f https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${LATEST}/kubevirt-cr-s390x.yaml
+
 ## Deploying from Source
 
 See the [Developer Getting Started
@@ -246,15 +254,15 @@ guide](https://github.com/kubevirt/ovs-cni/blob/main/docs/deployment-on-arbitrar
 
 ## Restricting KubeVirt components node placement
 
-You can restrict the placement of the KubeVirt components across your 
+You can restrict the placement of the KubeVirt components across your
 cluster nodes by editing the KubeVirt CR:
 
 - The placement of the KubeVirt control plane components (virt-controller, virt-api)
   is governed by the `.spec.infra.nodePlacement` field in the KubeVirt CR.
-- The placement of the virt-handler DaemonSet pods (and consequently, the placement of the 
+- The placement of the virt-handler DaemonSet pods (and consequently, the placement of the
   VM workloads scheduled to the cluster) is governed by the `.spec.workloads.nodePlacement`
   field in the KubeVirt CR.
-  
+
 For each of these `.nodePlacement` objects, the `.affinity`, `.nodeSelector` and `.tolerations` sub-fields can be configured.
 See the description in the [API reference](http://kubevirt.io/api-reference/master/definitions.html#_v1_componentconfig)
 for further information about using these fields.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add instructions on how to use the nightly builds for s390x architecture.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I have considered making the arm64 section more generic instead, but ultimately decided it would make the instructions needlessly compilecated.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add instructions for using kubevirt s390x developer builds
```
