### PR TITLE
Update persistent TPM & UEFI page to clarify storageclass requirements

### DIFF
--- a/docs/compute/persistent_tpm_and_uefi_state.md
+++ b/docs/compute/persistent_tpm_and_uefi_state.md
@@ -8,7 +8,7 @@ As of v1.0.0, KubeVirt supports using a PVC to persist those files. KubeVirt usu
 
 ## Backend storage
 
-KubeVirt automatically creates backend storage PVCs for VMs that need it. However, to persist TPM and UEFI state, the admin must first enable the `VMPersistentState` feature gate. `vmStateStorageClass` may be used to manually specify a storage class, otherwise the default storage class will be used.
+KubeVirt automatically creates backend storage PVCs for VMs that need it. However, to persist TPM and UEFI state, the admin must first enable the `VMPersistentState` feature gate. The KubeVirt CR configuration option `vmStateStorageClass` may be used to manually specify a storage class, otherwise the default storage class will be used.
 
 Here's an example of KubeVirt CR that sets both:
 ```yaml

--- a/docs/compute/persistent_tpm_and_uefi_state.md
+++ b/docs/compute/persistent_tpm_and_uefi_state.md
@@ -8,9 +8,7 @@ As of v1.0.0, KubeVirt supports using a PVC to persist those files. KubeVirt usu
 
 ## Backend storage
 
-KubeVirt automatically creates backend storage PVCs for VMs that need it. However, to persist TPM and UEFI state, the admin must first enable the `VMPersistentState` feature gate.
-
-If [live migration](live_migration.md) is required, then the `vmStateStorageClass` configuration parameter should be set, and must reference a storage class that supports read-write-many (RWX) in filesystem mode (FS).
+KubeVirt automatically creates backend storage PVCs for VMs that need it. However, to persist TPM and UEFI state, the admin must first enable the `VMPersistentState` feature gate. `vmStateStorageClass` may be used to manually specify a storage class, otherwise the default storage class will be used.
 
 Here's an example of KubeVirt CR that sets both:
 ```yaml
@@ -25,8 +23,6 @@ spec:
 ```
 
 ### Notes:
-- If no storage class is specified, the default storage class will be used
-- If the storage class has a storage profile that indicates it only supports read-write-once (RWO) then a RWO PVC will be created and the VMI will be marked as non-migratable.
 - Backend storage is currently incompatible with VM snapshot. It is planned to add snapshot support in the future.
 
 ## TPM with persistent state

--- a/docs/compute/persistent_tpm_and_uefi_state.md
+++ b/docs/compute/persistent_tpm_and_uefi_state.md
@@ -8,8 +8,10 @@ As of v1.0.0, KubeVirt supports using a PVC to persist those files. KubeVirt usu
 
 ## Backend storage
 
-KubeVirt automatically creates backend storage PVCs for VMs that need it. However, the admin must first enable the `VMPersistentState` feature gate, and tell KubeVirt which storage class to use by setting the `vmStateStorageClass` configuration parameter in the KubeVirt Custom Resource (CR).  
-The storage class must support read-write-many (RWX) in filesystem mode (FS).  
+KubeVirt automatically creates backend storage PVCs for VMs that need it. However, to persist TPM and UEFI state, the admin must first enable the `VMPersistentState` feature gate.
+
+If [live migration](live_migration.md) is required, then the `vmStateStorageClass` configuration parameter should be set, and must reference a storage class that supports read-write-many (RWX) in filesystem mode (FS).
+
 Here's an example of KubeVirt CR that sets both:
 ```yaml
 apiVersion: kubevirt.io/v1
@@ -22,9 +24,9 @@ spec:
       - VMPersistentState
 ```
 
-### Limitations
-
-- As mentioned above, the backend storage PVC can only be created using a storage class that supports RWX FS. There is ongoing work to support block storage in future versions of KubeVirt.
+### Notes:
+- If no storage class is specified, the default storage class will be used
+- If the storage class has a storage profile that indicates it only supports read-write-once (RWO) then a RWO PVC will be created and the VMI will be marked as non-migratable.
 - Backend storage is currently incompatible with VM snapshot. It is planned to add snapshot support in the future.
 
 ## TPM with persistent state


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Update [Persistent TPM and UEFI state](https://kubevirt.io/user-guide/compute/persistent_tpm_and_uefi_state/#backend-storage) to reflect the changes made in https://github.com/kubevirt/kubevirt/pull/11773

~Also, small spelling fix: prerequesites -> prerequisites~ (fixed in #846)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
