### PR TITLE
NUMA: Remove FG precondition and add v1.4 GA note

### DIFF
--- a/docs/compute/numa.md
+++ b/docs/compute/numa.md
@@ -13,6 +13,10 @@ The following NUMA mapping strategies can be used:
 
 - [**GuestMappingPassthrough**](#guestmappingpassthrough)
 
+**FEATURE STATE:** KubeVirt v1.4 GA
+
+The `NUMA` feature gate is now deprecated and as such enabled by default. The following [preconditions](#preconditions) still apply however.
+
 ## Preconditions
 
 In order to use current NUMA support, the following preconditions must be met:
@@ -20,9 +24,6 @@ In order to use current NUMA support, the following preconditions must be met:
 * [Dedicated CPU Resources](../compute/dedicated_cpu_resources.md) must be configured.
 * [Hugepages](../compute/virtual_hardware.md#hugepages) need to be allocatable on target
   nodes.
-* The `NUMA`
-  [feature gate](../cluster_admin/activating_feature_gates.md#how-to-activate-a-feature-gate)
-  must be enabled.
 
 ## GuestMappingPassthrough
 


### PR DESCRIPTION
**What this PR does / why we need it**:

FG GA'd by the following PR https://github.com/kubevirt/kubevirt/pull/12232

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
