### PR TITLE
Removing Alona and cwilkers from reviewers and approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,8 @@ filters:
     - hroyrh
     - danielBelenky
     - mazzystr
+    - AlonaKaplan
+    - cwilkers
 
   "^docs/.*":
     labels:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,8 +1,6 @@
 aliases:
   reviewers:
   - aburdenthehand
-  - AlonaKaplan
-  - cwilkers
   - dhiller
   - fabiand
   - jean-edouard
@@ -11,8 +9,6 @@ aliases:
   - vladikr
   approvers:
   - aburdenthehand
-  - AlonaKaplan
-  - cwilkers
   - davidvossel
   - dhiller
   - fabiand
@@ -35,19 +31,16 @@ aliases:
     - xpivarc
     - acardace
     - dhiller
-    - AlonaKaplan
 
   #
   # SIG Network
   # Owns anything related to networking.
   #
   sig-network-reviewers:
-    - AlonaKaplan
     - EdDev
     - RamLavi
     - ormergi
   sig-network-approvers:
-    - AlonaKaplan
     - EdDev
 
   #


### PR DESCRIPTION
Sad to say, it looks like Alona and cwilkers are no longer active in the project and it is time we moved them to emeritus.

Thank you @AlonaKaplan and @cwilkers for all your help with the user guide over the years. 