### PR TITLE
operations, network: Declare network hotplug feature as GA

### DIFF
--- a/docs/network/hotplug_interfaces.md
+++ b/docs/network/hotplug_interfaces.md
@@ -1,8 +1,10 @@
 # Hotplug Network Interfaces
 
 Release:
+
 - v1.1.0: Alpha
 - v1.3.0: Beta
+- v1.4.0: GA
 
 KubeVirt supports hotplugging and unplugging network interfaces into a running Virtual Machine (VM). 
 
@@ -24,10 +26,10 @@ to be added to a running pod. This is not trivial, and has some requirements:
   this Multus version exposes an endpoint to create attachments for a given pod
   on demand.
 
-### Enabling network interface hotplug support
-Network interface hotplug support must be enabled via a
-[feature gate](https://kubevirt.io/user-guide/operations/activating_feature_gates/#how-to-activate-a-feature-gate).
-The feature gates array in the KubeVirt CR must feature `HotplugNICs`.
+> **Note**: For older Kubevirt versions (from v1.1 until v1.3), the
+> `HotplugNICs` [feature-gate](https://kubevirt.io/user-guide/operations/activating_feature_gates/#how-to-activate-a-feature-gate))
+> must be enabled.
+> From Kubevirt v1.4, the FG is not needed and should be removed if set.
 
 ## Adding an interface to a running VM
 First start a VM. You can refer to the following example:


### PR DESCRIPTION
**What this PR does / why we need it**:

The network hotplug feature has been available since Kubevirt v1.1 as Alpha, followed in v1.3 as Beta.
There have been no changes in the API since and the feedback from users has been positive.

Therefore, the feature is declared GA towards v1.4.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```