### PR TITLE
docs, network, binding-plugins: Add a limited support note and bump to Beta

### DIFF
--- a/docs/network/network_binding_plugins.md
+++ b/docs/network/network_binding_plugins.md
@@ -4,6 +4,21 @@
 A modular plugin which integrates with Kubevirt to implement a
 network binding.
 
+> **Limited Support**: Kubevirt provides regular support for the network
+> binding plugin infrastructure for plugin authors.
+> However, individual network plugin bindings are subject to limited,
+> best-effort support from the Kubevirt community.
+>
+> Clusters with Kubevirt deployments that utilize a network binding
+> plugin should contact the plugin vendor for support on any issue that
+> may be encountered, be it network or other issue.
+>
+> In order to request support from the Kubevirt core project and its
+> community, please use a setup without any network binding plugin.
+> The [plugin examples](#plugins) listed below are an exception to this
+> rule, as they **are** maintained by the Kubevirt network core
+> maintainers.
+
 ## Overview
 
 ### Network Connectivity

--- a/docs/network/network_binding_plugins.md
+++ b/docs/network/network_binding_plugins.md
@@ -1,5 +1,5 @@
 # Network Binding Plugins
-[v1.1.0, Alpha feature]
+[v1.4.0, Beta feature]
 
 A modular plugin which integrates with Kubevirt to implement a
 network binding.


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduce a limited support for an individual network binding plugin.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
