### PR TITLE
Interfaces and networks: update the networks and interfaces sections

### DIFF
--- a/docs/network/interfaces_and_networks.md
+++ b/docs/network/interfaces_and_networks.md
@@ -186,12 +186,12 @@ spec:
 
 Network interfaces are configured in `spec.domain.devices.interfaces`.
 They describe properties of virtual interfaces as "seen" inside guest
-instances. The same network backend may be connected to a virtual
+instances. The same `network` may be connected to a virtual
 machine in multiple different ways, each with their own connectivity
 guarantees and characteristics.
 
-Each interface should declare its type by defining on of the following
-fields:
+The mandatory interface configuration includes a `name`, 
+which references a network name and either a type from the table below, or a [network binding plugin](https://kubevirt.io/user-guide/network/network_binding_plugins/) reference.
 
 <table>
 <colgroup>
@@ -210,16 +210,12 @@ fields:
 <td><p>Connect using a linux bridge</p></td>
 </tr>
 <tr class="even">
-<td><p><code>slirp</code></p></td>
-<td><p>Connect using QEMU user networking mode</p></td>
-</tr>
-<tr class="odd">
 <td><p><code>sriov</code></p></td>
 <td><p>Pass through a SR-IOV PCI device via <code>vfio</code></p></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><p><code>masquerade</code></p></td>
-<td><p>Connect using Iptables rules to nat the traffic</p></td>
+<td><p>Connect using nftables rules to nat the traffic<br>both egress and ingress</p></td>
 </tr>
 </tbody>
 </table>
@@ -259,7 +255,7 @@ properties "seen" inside guest instances, as listed below:
 <td><p>ports</p></td>
 <td></td>
 <td><p>empty</p></td>
-<td><p>List of ports to be forwarded to the virtual machine.</p></td>
+<td><p>Allow-list of ports to be forwarded to the virtual machine.</p></td>
 </tr>
 <tr class="even">
 <td><p>pciAddress</p></td>
@@ -281,7 +277,7 @@ spec:
           masquerade: {} # connect through a masquerade
           ports:
            - name: http
-             port: 80
+             port: 80 # allow only http traffic ingress
   networks:
   - name: default
     pod: {}
@@ -289,7 +285,7 @@ spec:
 
 > **Note:** For secondary interfaces, when a MAC address is specified for a
 > virtual machine interface, it is passed to the underlying CNI plugin which is,
-> in turn, expected to configure the backend to allow for this particular MAC.
+> in turn, expected to configure the network provider to allow for this particular MAC.
 > Not every plugin has native support for custom MAC addresses.
 
 > **Note:** For some CNI plugins without native support for custom MAC
@@ -333,10 +329,7 @@ spec:
 >
 ### Ports
 
-Declare ports listen by the virtual machine
-
-> **Note:** When using the slirp interface only the configured ports
-> will be forwarded to the virtual machine.
+Allow-list of ports that are forwarded to the VM, if empty all ports are allowed
 
 <table>
 <colgroup>


### PR DESCRIPTION
This PR is rebased on top of https://github.com/kubevirt/user-guide/pull/843
Please ignore the first commit as it is reviewed as part of the other PR  mentioned above
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Updates the Netwoks and the Interfaces sections, clean up clutter and mention recent functionality 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
