### PR TITLE
common-instancetypes: Remove FG and update docs

### DIFF
--- a/docs/user_workloads/deploy_common_instancetypes.md
+++ b/docs/user_workloads/deploy_common_instancetypes.md
@@ -5,11 +5,21 @@ The [`kubevirt/common-instancetypes`](https://github.com/kubevirt/common-instanc
 Beginning with the 1.1 release of KubeVirt, cluster wide resources can be deployed directly through KubeVirt, without another operator.
 This allows deployment of a set of default instancetypes and preferences along side KubeVirt.
 
-## Enable automatic deployment of common-instancetypes
+With the [`v1.4.0`](https://github.com/kubevirt/kubevirt/releases/tag/v1.4.0) release of KubeVirt, common-instancetypes are now deployed by default.
 
-To enable the deployment of cluster-wide common-instancetypes through the KubeVirt `virt-operator`, the `CommonInstancetypesDeploymentGate` feature gate needs to be enabled.
+## **FEATURE STATE:** 
 
-See [Activating feature gates](../cluster_admin/activating_feature_gates.md) on how to enable it.
+* Alpha - [`v1.1.0`](https://github.com/kubevirt/kubevirt/releases/tag/v1.1.0)
+* Beta - [`v1.2.0`](https://github.com/kubevirt/kubevirt/releases/tag/v1.2.0)
+* GA - [`v1.4.0`](https://github.com/kubevirt/kubevirt/releases/tag/v1.4.0) (Enabled by default)
+
+## Control deployment of common-instancetypes
+
+To explictly enable or disable the deployment of cluster-wide common-instancetypes through the KubeVirt `virt-operator` use the `spec.configuration.commonInstancetypesDeployment.enable` configurable.
+
+```shell
+$ kubectl patch -n kubevirt kv/kubevirt --type merge -p '{"spec":{"configuration":{"commonInstancetypesDeployment":{"enable": false}}}}'
+```
 
 ## Deploy common-instancetypes manually
 


### PR DESCRIPTION
/cc @jcanocan 

**What this PR does / why we need it**:

The FG controlling the common-instancetypes deployment feature has GA'd with KubeVirt v1.4.0 so remove the reference and update our docs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
