### PR TITLE
Change spec.running refs to runStrategy

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,27 +160,15 @@ with `spec.replica` set to `1`.
 ## How to use a VirtualMachine
 
 A VirtualMachine will make sure that a VirtualMachineInstance object
-with an identical name will be present in the cluster, if `spec.runStrategy`
-is set to `Always`. Further it will make sure that a
-VirtualMachineInstance will be removed from the cluster if
-`spec.runStrategy` is set to `Halted`.
-
-`spec.runStrategy` has several additional options for
-controlling the state of the associated VirtualMachineInstance object.
-An extended explanation of `spec.runStrategy` can be
-found in [Run Strategies](./compute/run_strategies.md)
+with an identical name will be present in the cluster when the VirtualMachine
+is in a Running state, which is controlled via the `spec.runStrategy` field.
+For more information regarding Run Strategies, please refer to [Run Strategies](./compute/run_strategies.md)
 
 ### Starting and stopping
 
-After creating a VirtualMachine it can be switched on or off like this:
-
-    # Start the virtual machine:
-    virtctl start vm
-
-    # Stop the virtual machine:
-    virtctl stop vm
-
-`kubectl` can be used too:
+Virtual Machines can be turned on/off in an imperative or a declarative manner.
+Setting a `spec.runStrategy` like `Always` or `Halted` means that the system will continuously
+try to ensure the Virtual Machine is turned on/off:
 
     # Start the virtual machine:
     kubectl patch virtualmachine vm --type merge -p \
@@ -189,6 +177,15 @@ After creating a VirtualMachine it can be switched on or off like this:
     # Stop the virtual machine:
     kubectl patch virtualmachine vm --type merge -p \
         '{"spec":{"runStrategy": "Halted"}}'
+
+However, with the `Manual` `runStrategy`, the user would imperatively choose when to turn
+the VM on or off, without the system performing any automatic actions:
+
+    # Start the virtual machine:
+    virtctl start vm
+
+    # Stop the virtual machine:
+    virtctl stop vm
 
 Find more details about [a VM's life-cycle in the relevant section](./user_workloads/lifecycle.md)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,17 +160,14 @@ with `spec.replica` set to `1`.
 ## How to use a VirtualMachine
 
 A VirtualMachine will make sure that a VirtualMachineInstance object
-with an identical name will be present in the cluster, if `spec.running`
-is set to `true`. Further it will make sure that a
+with an identical name will be present in the cluster, if `spec.runStrategy`
+is set to `Always`. Further it will make sure that a
 VirtualMachineInstance will be removed from the cluster if
-`spec.running` is set to `false`.
+`spec.runStrategy` is set to `Halted`.
 
-There exists a field `spec.runStrategy` which can also be used to
-control the state of the associated VirtualMachineInstance object. To
-avoid confusing and contradictory states, these fields are mutually
-exclusive.
-
-An extended explanation of `spec.runStrategy` vs `spec.running` can be
+`spec.runStrategy` has several additional options for
+controlling the state of the associated VirtualMachineInstance object.
+An extended explanation of `spec.runStrategy` can be
 found in [Run Strategies](./compute/run_strategies.md)
 
 ### Starting and stopping
@@ -187,11 +184,11 @@ After creating a VirtualMachine it can be switched on or off like this:
 
     # Start the virtual machine:
     kubectl patch virtualmachine vm --type merge -p \
-        '{"spec":{"running":true}}'
+        '{"spec":{"runStrategy": "Always"}}'
 
     # Stop the virtual machine:
     kubectl patch virtualmachine vm --type merge -p \
-        '{"spec":{"running":false}}'
+        '{"spec":{"runStrategy": "Halted"}}'
 
 Find more details about [a VM's life-cycle in the relevant section](./user_workloads/lifecycle.md)
 
@@ -327,7 +324,7 @@ metadata:
     kubevirt.io/vm: vm-cirros
   name: vm-cirros
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:
@@ -448,7 +445,7 @@ demonstrating how to do it.
 
     # Start the virtual machine:
     kubectl patch virtualmachine vm --type merge -p \
-        '{"spec":{"running":true}}'
+        '{"spec":{"runStrategy":"Always"}}'
 
     # Look at virtual machine status and associated events:
     kubectl describe virtualmachine vm
@@ -458,7 +455,7 @@ demonstrating how to do it.
 
     # Stop the virtual machine instance:
     kubectl patch virtualmachine vm --type merge -p \
-        '{"spec":{"running":false}}'
+        '{"spec":{"runStrategy":"Halted"}}'
 
     # Restart the virtual machine (you delete the instance!):
     kubectl delete virtualmachineinstance vm

--- a/docs/cluster_admin/ksm.md
+++ b/docs/cluster_admin/ksm.md
@@ -81,7 +81,7 @@ kind: VirtualMachine
 metadata:
   name: testvm
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       labels:

--- a/docs/cluster_admin/scheduler.md
+++ b/docs/cluster_admin/scheduler.md
@@ -62,7 +62,7 @@ kind: VirtualMachine
 metadata:
   name: vm-fedora
 spec:
-  running: true
+  runStrategy: Always
   template:
     spec:
       schedulerName: my-scheduler

--- a/docs/compute/numa.md
+++ b/docs/compute/numa.md
@@ -125,7 +125,7 @@ metadata:
     kubevirt.io/vm: fedora-realtime
   name: fedora-realtime
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       labels:

--- a/docs/compute/run_strategies.md
+++ b/docs/compute/run_strategies.md
@@ -34,6 +34,9 @@ RunStrategies defined:
     Note: Guest sided crashes (i.e. BSOD) are not covered by this.
     In such cases liveness checks or the use of a watchdog can help.
 
+-   Once: The VM will run once and not be restarted upon completion
+    regardless if the completion is of phase Failure or Success.
+
 -   Manual: The system will not automatically turn the VM on or off,
     instead the user manually controlls the VM status by issuing
     start, stop, and restart commands on the VirtualMachine

--- a/docs/network/hotplug_interfaces.md
+++ b/docs/network/hotplug_interfaces.md
@@ -40,7 +40,7 @@ kind: VirtualMachine
 metadata:
   name: vm-fedora
 spec:
-  running: true
+  runStrategy: Always
   template:
     spec:
       domain:

--- a/docs/network/net_binding_plugins/macvtap.md
+++ b/docs/network/net_binding_plugins/macvtap.md
@@ -185,7 +185,7 @@ metadata:
     kubevirt.io/vm: vm-net-binding-macvtap
   name: vm-net-binding-macvtap
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       labels:

--- a/docs/network/net_binding_plugins/passt.md
+++ b/docs/network/net_binding_plugins/passt.md
@@ -176,7 +176,7 @@ metadata:
     kubevirt.io/vm: vm-net-binding-passt
   name: vm-net-binding-passt
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       labels:

--- a/docs/network/net_binding_plugins/slirp.md
+++ b/docs/network/net_binding_plugins/slirp.md
@@ -69,7 +69,7 @@ metadata:
     kubevirt.io/vm: vm-net-binding-slirp
   name: vm-net-binding-passt
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       labels:

--- a/docs/network/network_binding_plugins.md
+++ b/docs/network/network_binding_plugins.md
@@ -275,7 +275,7 @@ metadata:
     kubevirt.io/vm: vm-net-binding-passt
   name: vm-net-binding-passt
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       labels:

--- a/docs/storage/disks_and_volumes.md
+++ b/docs/storage/disks_and_volumes.md
@@ -559,7 +559,7 @@ metadata:
     kubevirt.io/vm: vm-alpine-datavolume
   name: vm-alpine-datavolume
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:
@@ -1784,7 +1784,7 @@ metadata:
     kubevirt.io/vm: vm-block-1
   name: vm-block-1
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       labels:
@@ -1830,7 +1830,7 @@ metadata:
     kubevirt.io/vm: vm-block-2
   name: vm-block-2
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       labels:
@@ -2065,7 +2065,7 @@ metadata:
     kubevirt.io/vm: hostpath-vm
   name: hostpath
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       labels:

--- a/docs/storage/export_api.md
+++ b/docs/storage/export_api.md
@@ -413,7 +413,7 @@ spec:
       source:
         registry:
           url: docker://quay.io/containerdisks/centos-stream:9
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:
@@ -561,7 +561,7 @@ spec:
       source:
         registry:
           url: docker://quay.io/containerdisks/centos-stream:9
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/docs/user_workloads/accessing_virtual_machines.md
+++ b/docs/user_workloads/accessing_virtual_machines.md
@@ -115,7 +115,7 @@ kind: VirtualMachine
 metadata:
   name: testvm
 spec:
-  running: true
+  runStrategy: Always
   template:
     spec:
       domain:
@@ -196,7 +196,7 @@ kind: VirtualMachine
 metadata:
   name: testvm
 spec:
-  running: true
+  runStrategy: Always
   template:
     spec:
       domain:

--- a/docs/user_workloads/instancetypes.md
+++ b/docs/user_workloads/instancetypes.md
@@ -79,7 +79,7 @@ spec:
   preference:
     kind: VirtualMachinePreference
     name: example-preference-disk-virtio
-  running: false
+  runStrategy: Halted
   template:
     spec:
       domain:
@@ -408,7 +408,7 @@ spec:
     inferFromVolume: cirros-volume
   preference:
     inferFromVolume: cirros-volume
-  running: false
+  runStrategy: Halted
   dataVolumeTemplates:
     - metadata:
         name: cirros-datavolume
@@ -472,7 +472,7 @@ spec:
   preference:
     inferFromVolume: cirros-volume
     inferFromVolumeFailurePolicy: Ignore
-  running: false
+  runStrategy: Halted
   dataVolumeTemplates:
     - metadata:
         name: cirros-datavolume

--- a/docs/user_workloads/pool.md
+++ b/docs/user_workloads/pool.md
@@ -60,7 +60,7 @@ spec:
       labels:
         kubevirt.io/vmpool: vm-pool-cirros
     spec:
-      running: true
+      runStrategy: Always
       template:
         metadata:
           creationTimestamp: null

--- a/docs/user_workloads/startup_scripts.md
+++ b/docs/user_workloads/startup_scripts.md
@@ -695,7 +695,7 @@ kind: VirtualMachine
 metadata:
   name: ign-demo
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:
@@ -811,7 +811,7 @@ kind: VirtualMachine
 metadata:
   name: windows-with-sysprep
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:
@@ -869,7 +869,7 @@ kind: VirtualMachine
 metadata:
   name: windows-with-sysprep
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/docs/user_workloads/templates.md
+++ b/docs/user_workloads/templates.md
@@ -167,7 +167,7 @@ items:
           pvc:
             name: rhel
             namespace: kubevirt
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         labels:
@@ -354,7 +354,7 @@ items:
     defaults.template.kubevirt.io/disk: rhel-default-disk
     defaults.template.kubevirt.io/nic: rhel-default-net
   spec:
-    running: false
+    runStrategy: Halted
     template:
       spec:
         domain:
@@ -392,7 +392,7 @@ metadata:
   name: rheltinyvm
   osinfoname: rhel7.0
 spec:
-  running: false
+  runStrategy: Halted
   template:
     spec:
       domain:
@@ -543,7 +543,7 @@ objects:
           pvc:
             name: ${SRC_PVC_NAME}
             namespace: ${SRC_PVC_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         labels:
@@ -669,7 +669,7 @@ preferred way how to do this from within the OpenShift environment is to
 use `oc patch` command.
 
 ```console
-$ oc patch virtualmachine testvm --type merge -p '{"spec":{"running":true}}'
+$ oc patch virtualmachine testvm --type merge -p '{"spec":{"runStrategy":"Always"}}'
 virtualmachine.kubevirt.io/testvm patched
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Change deprecated spec.running references to runStrategy.

**Which issue(s) this PR fixes**:
jira-ticket: https://issues.redhat.com/browse/CNV-45433

**Release note**:
```release-note
Change deprecated spec.running references to runStrategy
```