### PR TITLE
(migration_policies) fix wrong spec indentation

### DIFF
--- a/docs/cluster_admin/migration_policies.md
+++ b/docs/cluster_admin/migration_policies.md
@@ -39,7 +39,7 @@ MigrationConfiguration (in the future more configurations that aren't part of Ku
 ```yaml
 apiVersion: migrations.kubevirt.io/v1alpha1
 kind: MigrationPolicy
-  spec:
+spec:
     allowAutoConverge: true
     bandwidthPerMigration: 217Ki
     completionTimeoutPerGiB: 23
@@ -60,7 +60,7 @@ are the following.
 ```yaml
 apiVersion: migrations.kubevirt.io/v1alpha1
 kind: MigrationPolicy
-  spec:
+spec:
   selectors:
     namespaceSelector:
       hpc-workloads: true       # Matches a key and a value 
@@ -70,7 +70,7 @@ kind: MigrationPolicy
 ```yaml
 apiVersion: migrations.kubevirt.io/v1alpha1
 kind: MigrationPolicy
-  spec:
+spec:
   selectors:
     virtualMachineInstanceSelector:
       workload-type: db       # Matches a key and a value 
@@ -80,7 +80,7 @@ kind: MigrationPolicy
 ```yaml
 apiVersion: migrations.kubevirt.io/v1alpha1
 kind: MigrationPolicy
-  spec:
+spec:
   selectors:
     namespaceSelector:
       hpc-workloads: true


### PR DESCRIPTION
**What this PR does / why we need it**: Fix a wrong indentation in a few yaml examples in the [Migration Policies documentation](https://kubevirt.io/user-guide/cluster_admin/migration_policies/#api-examples)

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
