### PR TITLE
Change clone API version from v1alpha1 to v1beta1

### DIFF
--- a/docs/storage/clone_api.md
+++ b/docs/storage/clone_api.md
@@ -7,7 +7,7 @@ This API has two main use-cases:
 * Creating "golden snapshots" that would be used as a template for creating new VMs
 (see [Using clones as a "golden VM image"](#using-clones-as-a-golden-vm-image) below).
 
-Please bear in mind that the clone API is in version `v1alpha1`. This means that this API is not fully stable
+Please bear in mind that the clone API is in version `v1beta1`. This means that this API is not fully stable
 yet and that APIs may change in the future.
 
 ## Prerequisites
@@ -34,7 +34,7 @@ In order to initiate cloning, a `VirtualMachineClone` object (CRD) needs to be c
 for such an object is:
 ```yaml
 kind: VirtualMachineClone
-apiVersion: "clone.kubevirt.io/v1alpha1"
+apiVersion: "clone.kubevirt.io/v1beta1"
 metadata:
   name: testclone
 


### PR DESCRIPTION
To align with: https://github.com/kubevirt/kubevirt/pull/13520

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change clone API version from v1alpha1 to v1beta1
```
