### PR TITLE
vmpool: Update how to use individual configuration per VM

### DIFF
--- a/docs/user_workloads/pool.md
+++ b/docs/user_workloads/pool.md
@@ -264,9 +264,9 @@ means if you specify a secret in a `CloudInitNoCloud` volume, that every VM inst
 from the VirtualMachinePool with this volume will get the exact same secret used for their cloud-init
 user data.
 
-This default behavior can be modified by setting the `AppendPostfixToSecretReferences` and
-`AppendPostfixToConfigMapReferences` booleans to true on the VMPool spec. When these booleans
-are enabled, references to secret and configMap names will have the VM's sequential postfix
+This default behavior can be modified by setting both the `AppendIndexToSecretRefs` and
+`AppendIndexToConfigMapRefs` booleans to `true` within `spec.NameGeneration` of the VMPool definition.
+When these booleans are enabled, references to secret and configMap names will have the VM's sequential index
 appended to the secret and configmap name. This allows someone to pre-generate unique per VM
 `secret` and `configMap` data for a VirtualMachinePool ahead of time in a way that will be predictably
 assigned to VMs within the VirtualMachinePool.


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Update the description for using individual configuration per VM to match the actual implementation in KubeVirt.

See https://github.com/kubevirt/kubevirt/pull/13642 and https://github.com/kubevirt/user-guide/issues/848

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
