### PR TITLE
Fix the number of RunStrategies in RunStrategies.md

### DIFF
--- a/docs/compute/run_strategies.md
+++ b/docs/compute/run_strategies.md
@@ -15,7 +15,7 @@ the VirtualMachineInstance.
 
 To allow for greater variation of user states, the `RunStrategy` field
 has been introduced. This is mutually exclusive with `Running` as they
-have somewhat overlapping conditions. There are currently four
+have somewhat overlapping conditions. There are currently five
 RunStrategies defined:
 
 -   Always: The system is tasked with keeping the VM in a running


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
There are currently **FIVE** RunStrategies defined（**But the current document says four**）:

Always: The system is tasked with keeping the VM in a running state. This is achieved by respawning a VirtualMachineInstance whenever the current one terminated in a controlled (e.g. shutdown from inside the guest) or uncontrolled (e.g. crash) way. This behavior is equal to spec.running: true.

RerunOnFailure: Similar to Always, except that the VM is only restarted if it terminated in an uncontrolled way (e.g. crash) and due to an infrastructure reason (i.e. the node crashed, the KVM related process OOMed). This allows a user to determine when the VM should be shut down by initiating the shut down inside the guest. Note: Guest sided crashes (i.e. BSOD) are not covered by this. In such cases liveness checks or the use of a watchdog can help.

Once: The VM will run once and not be restarted upon completion regardless if the completion is of phase Failure or Success.

Manual: The system will not automatically turn the VM on or off, instead the user manually controlls the VM status by issuing start, stop, and restart commands on the VirtualMachine subresource endpoints.

Halted: The system is asked to ensure that no VM is running. This is achieved by stopping any VirtualMachineInstance that is associated ith the VM. If a guest is already running, it will be stopped. This behavior is equal to spec.running: false.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

