### PR TITLE
Update documentation about dynamic SSH key injection

### DIFF
--- a/docs/user_workloads/accessing_virtual_machines.md
+++ b/docs/user_workloads/accessing_virtual_machines.md
@@ -161,21 +161,24 @@ This allows for dynamic injection of SSH public keys at runtime by updating the 
 
 Please note that new Secrets cannot be attached to a running VM: You must restart the VM to attach the new Secret.
 
-> Note: This requires the qemu-guest-agent to be installed within the guest.
->
-> Note: When using qemuGuestAgent propagation,
-> the `/home/$USER/.ssh/authorized_keys` file will be owned by the guest agent.
+> **Requirement:** The qemu-guest-agent must be installed within the guest.
+
+> **Deprecation Notice:** The implementation supporting qemu-guest-agent versions older than 5.2 is deprecated
+> and will stop working in a future release.
+
+> **Important:** When using `qemuGuestAgent` propagation,
+> the `/home/$USER/.ssh/authorized_keys` file is owned by the guest agent.
 > Changes to the file not made by the guest agent will be lost.
->
-> Note: More information about the motivation behind the access credentials API
+
+> **Further Reading:** More information about the motivation behind the access credentials API
 > can be found in the
 > [pull request description](https://github.com/kubevirt/kubevirt/pull/4195)
 > that introduced the API.
 
-In the example below the `Secret` containing the SSH public key is
+In the example below, the `Secret` containing the SSH public key is
 attached to the virtual machine via the access credentials API with the
 `qemuGuestAgent` propagation method. This allows updating the contents of
-the `Secret` at any time, which will result in the changes getting applied
+the `Secret` at any time, which will result in the changes being applied
 to the running virtual machine immediately. The `Secret` may also contain
 multiple SSH public keys.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Added deprecation notice, that in a future release dynamic SSH key injection will stop working for older guest agents
- Changed wording, so that there are not 4 `Note:...` blocks right next to each other.

**Special notes for your reviewer**:
This should be merged after the deprecation PR is merged: https://github.com/kubevirt/kubevirt/pull/13881

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
None
```
