### PR TITLE
Removing need for VolumeUpdateStrategy and VolumeMigration feature gates

### DIFF
--- a/docs/storage/volume_migration.md
+++ b/docs/storage/volume_migration.md
@@ -104,7 +104,7 @@ by updating the VM:
 The destination volume may be of a different type or size than the source. It is possible to migrate from and to a block volume as well as a filesystem volume.
 The destination volume should be equal to or larger than the source volume. However, the additional difference in the size of the destination volume is not instantly visible within the VM and must be manually resized because the guest is unaware of the migration.
 
-The volume migration depends on the `VolumeMigration` and `VolumesUpdateStrategy` feature gates and the `LiveMigrate` workloadUpdateStrategy. To fully enable the feature, add the following to the KubeVirt CR:
+The volume migration depends on the `LiveMigrate` workloadUpdateStrategy. To fully enable the feature, add the following to the KubeVirt CR:
 ```yaml
 apiVersion: kubevirt.io/v1
 kind: KubeVirt
@@ -113,8 +113,6 @@ spec:
     developerConfiguration:
       featureGates:
         - VMLiveUpdateFeatures
-        - VolumesUpdateStrategy
-        - VolumeMigration
     vmRolloutStrategy: LiveUpdate
   workloadUpdateStrategy:
     workloadUpdateMethods:


### PR DESCRIPTION
As per https://github.com/kubevirt/kubevirt/pull/13288
These features gates are no longer required. 

@alicefr 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removing need for VolumeUpdateStrategy and VolumeMigration feature gates
```
