### PR TITLE
Remove VMLiveUpdateFeatures FG references

### DIFF
--- a/docs/compute/cpu_hotplug.md
+++ b/docs/compute/cpu_hotplug.md
@@ -12,19 +12,6 @@ Per each new socket that is hot-plugged, the amount of new vCPUs that would be s
 
 ## Configuration
 
-### Enable feature-gate
-In order to enable CPU hotplug we need to add the `VMLiveUpdateFeatures` feature gate in Kubevirt CR:
-
-```yaml
-apiVersion: kubevirt.io/v1
-kind: KubeVirt
-spec:
-  configuration:
-    developerConfiguration:
-      featureGates:
-        - VMLiveUpdateFeatures
-```
-
 ### Configure the workload update strategy
 Current implementation of the hotplug process requires the VM to live-migrate.
 The migration will be triggered automatically by the workload updater. The workload update strategy in the KubeVirt CR must be configured with `LiveMigrate`, as follows:

--- a/docs/compute/memory_hotplug.md
+++ b/docs/compute/memory_hotplug.md
@@ -12,20 +12,6 @@ Memory hotplug was introduced in KubeVirt version 1.1, enabling the dynamic resi
 
 # Configuration
 
-### Enable feature-gate
-
-To use memory hotplug we need to add the `VMLiveUpdateFeatures` feature gate in the KubeVirt CR:
-
-```yaml
-apiVersion: kubevirt.io/v1
-kind: KubeVirt
-spec:
-  configuration:
-    developerConfiguration:
-      featureGates:
-        - VMLiveUpdateFeatures
-```
-
 ### Configure the Workload Update Strategy
 
 Configure `LiveMigrate` as `workloadUpdateStrategy` in the KubeVirt CR, since the current implementation of the hotplug process requires the VM to live-migrate.
@@ -73,10 +59,9 @@ The VM-level configuration will take precedence over the cluster-wide one.
 
 ## Memory Hotplug in Action
 
-First we enable the `VMLiveUpdateFeatures` feature gate, set the rollout strategy to `LiveUpdate` and set `LiveMigrate` as `workloadUpdateStrategy` in the KubeVirt CR.
+First we set the rollout strategy to `LiveUpdate` and `LiveMigrate` as `workloadUpdateStrategy` in the KubeVirt CR.
 
 ```sh
-$ kubectl --namespace kubevirt patch kv kubevirt -p='[{"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates", "value": ["VMLiveUpdateFeatures"]}]' --type='json'
 $ kubectl --namespace kubevirt patch kv kubevirt -p='[{"op": "add", "path": "/spec/configuration/vmRolloutStrategy", "value": "LiveUpdate"}]' --type='json'
 $ kubectl --namespace kubevirt patch kv kubevirt -p='[{"op": "add", "path": "/spec/workloadUpdateStrategy/workloadUpdateMethods", "value": ["LiveMigrate"]}]' --type='json'
 ```

--- a/docs/storage/disks_and_volumes.md
+++ b/docs/storage/disks_and_volumes.md
@@ -2121,7 +2121,7 @@ The following strategies are supported:
     found in the [volume migration documentation](../storage/volume_migration.md).
 
 The update volume migration depends on the feature gate `VolumesUpdateStrategy`
-which depends on the VMLiveUpdateFeatures feature gate and configuration.
+which depends on the workloadUpdateStrategy configuration.
 
 KubeVirt CR:
 ```yaml
@@ -2131,7 +2131,6 @@ spec:
   configuration:
     developerConfiguration:
       featureGates:
-        - VMLiveUpdateFeatures
         - VolumesUpdateStrategy
   workloadUpdateStrategy:
     workloadUpdateMethods:

--- a/docs/storage/volume_migration.md
+++ b/docs/storage/volume_migration.md
@@ -110,9 +110,6 @@ apiVersion: kubevirt.io/v1
 kind: KubeVirt
 spec:
   configuration:
-    developerConfiguration:
-      featureGates:
-        - VMLiveUpdateFeatures
     vmRolloutStrategy: LiveUpdate
   workloadUpdateStrategy:
     workloadUpdateMethods:

--- a/docs/user_workloads/vm_rollout_strategies.md
+++ b/docs/user_workloads/vm_rollout_strategies.md
@@ -6,21 +6,6 @@ In other words, it defines when and how changes to a VM object get propagated to
 There are currently 2 rollout strategies: `LiveUpdate` and `Stage`.
 Only 1 can be specified and the default is `Stage`.
 
-## Feature Gate
-
-As long as the `VMLiveUpdateFeatures` is not enabled, the VM Rollout Strategy is ignored and defaults to "Stage".
-The feature gate is set in the KubeVirt custom resource (CR) like that:
-
-```yaml
-apiVersion: kubevirt.io/v1
-kind: KubeVirt
-spec:
-  configuration:
-    developerConfiguration:
-      featureGates:
-        - VMLiveUpdateFeatures
-```
-
 ## LiveUpdate
 
 The `LiveUpdate` VM rollout strategy tries to propagate VM object changes to running VMIs as soon as possible.  


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Starting from https://github.com/kubevirt/kubevirt/pull/13091
the `VMLiveUpdateFeaturesfeature` is not needed anymore.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removing need for VMLiveUpdateFeaturesfeature gate
```

/cc @aburdenthehand 