### PR TITLE
Remove docs regarding AutoResourceLimits FeatureGate

### DIFF
--- a/docs/compute/resources_requests_and_limits.md
+++ b/docs/compute/resources_requests_and_limits.md
@@ -18,19 +18,15 @@ Note: dedicated CPUs (and isolated emulator thread) are ignored here as they hav
 - Manually setting CPU limits on the VM(I) will override all of the above and be the CPU limits for the container
 
 ### Auto CPU limits
-KubeVirt provides two ways to automatically set CPU limits on VM(I)s:
-
-- Enable the `AutoResourceLimitsGate` feature gate.
-- Add the namespaceLabelSelector in the KubeVirt CR.
-
-In both cases, the VM(I) created will have a CPU limit of 1 per vCPU.
-
-#### AutoResourceLimitsGate feature gate
-By enabling this feature gate, cpu limits will be added to the vmi if all the following conditions are true:
+KubeVirt automatically set CPU limits on VM(I)s if all the following conditions are true:
 
 - The namespace where the VMI will be created has a ResourceQuota containing cpu limits.
 - The VMI has no manually set cpu limits.
 - The VMI is not requesting dedicated CPU.
+
+Additionally, you can add the namespaceLabelSelector in the KubeVirt CR, forcing CPU limits to be set.
+
+In both cases, the VM(I) created will have a CPU limit of 1 per vCPU.
 
 #### autoCPULimitNamespaceLabelSelector configuration
 Cluster admins can define a label selector in the KubeVirt CR.  
@@ -78,8 +74,7 @@ metadata:
 
 
 ### Auto memory limits
-KubeVirt provides a feature gate(`AutoResourceLimitsGate`) to automatically set memory limits on VM(I)s.
-By enabling this feature gate, memory limits will be added to the vmi if all the following conditions are true:
+KubeVirt automatically set memory limits on VM(I)s if all the following conditions are true:
 
 - The namespace where the VMI will be created has a ResourceQuota containing memory limits.
 - The VMI has no manually set memory limits.


### PR DESCRIPTION
As it is GAed already

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
