### PR TITLE
Volume hotplug: clear up docs --persist

### DIFF
--- a/docs/storage/hotplug_volumes.md
+++ b/docs/storage/hotplug_volumes.md
@@ -85,36 +85,18 @@ $ virtctl addvolume vmi-fedora --volume-name=example-lun-hotplug --disk-type=lun
 ```
 
 ### Retain hotplugged volumes after restart
-In many cases it is desirable to keep hotplugged volumes after a VM restart. It may also be desirable to be able to unplug these volumes after the restart. The `persist` option makes it impossible to unplug the disks after a restart. If you don't specify `persist` the default behaviour is to retain hotplugged volumes as hotplugged volumes after a VM restart. This makes the `persist` flag mostly obsolete unless you want to make a volume permanent on restart.
+In many cases it is desirable to keep hotplugged volumes after a VM restart. It may also be desirable to be able to unplug these volumes after the restart. The `persist` option makes it possible to unplug the disks after a restart. If you don't specify `persist`, the volume is only ever hotplugged on the VMI (instance) level.
 
 ### Persist
-In some cases you want a hotplugged volume to become part of the standard disks after a restart of the VM.
-For instance if you added some permanent storage to the VM. We also assume that the running VMI has a matching VM that defines it specification.
-You can call the addvolume command with the --persist flag. This will update the VM domain disks section in addition to updating the VMI domain disks.
-This means that when you restart the VM, the disk is already defined in the VM, and thus in the new VMI.
+In some cases you want a hotplugged volume to stay hotplugged after a restart of the VM.
+In that case, you can call the addvolume command with the --persist flag.
+This means that when you restart the VM, the disk is already defined in the VM (as hotplugged), and thus is hotplugged to the new VMI.
 
 ```bash
 $ virtctl addvolume vm-fedora --volume-name=example-volume-hotplug --persist
 ```
 
-In the VM spec this will now show as a new disk
-```yaml
-spec:
-domain:
-    devices:
-        disks:
-        - disk:
-            bus: virtio
-            name: containerdisk
-        - disk:
-            bus: virtio
-            name: cloudinitdisk
-        - disk:
-            bus: scsi
-            name: example-volume-hotplug
-    machine:
-      type: ""
-```
+> *NOTE* The persist flag could also be used with removevolume to unplug in the same manner
 
 ### Removevolume
 In addition to hotplug plugging the volume, you can also unplug it by using the 'removevolume' command available with virtctl


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Things have changed since the doc was introduced,
update to reflect that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Clear up hotplug volume docs around --persist
```
