### PR TITLE
Ensure "Node CPU allocation ratio" is listed in the ToC

### DIFF
--- a/docs/compute/node_overcommit.md
+++ b/docs/compute/node_overcommit.md
@@ -205,7 +205,7 @@ since KSM merges identical pages over time. Swap allows the VMIs to
 successfully allocate memory which will then effectively never be used
 because of the later de-duplication done by KSM.
 
-# Node CPU allocation ratio
+## Node CPU allocation ratio
 
 KubeVirt runs Virtual Machines in a Kubernetes Pod. This pod requests a certain
 amount of CPU time from the host. On the other hand, the Virtual Machine is


### PR DESCRIPTION
Last section "Node CPU allocation ratio" is not showing on the  table of contents.

This is a minor 1 char addition to the documentation only.
