### PR TITLE
net, ifaces: Fix ports section

### DIFF
--- a/docs/network/interfaces_and_networks.md
+++ b/docs/network/interfaces_and_networks.md
@@ -426,12 +426,19 @@ spec:
         devices:
           interfaces:
             - name: red
-              masquerade: {} # connect using masquerade mode
-              ports:
-                - port: 80 # allow incoming traffic on port 80 to get into the virtual machine
+              masquerade: {} 
       networks:
       - name: red
         pod: {}
+    volumes:
+      - cloudInitNoCloud:
+          networkData: |
+            version: 2
+            ethernets:
+              eth0:
+                dhcp4: true
+                addresses: [ fd10:0:2::2/120 ]
+                gateway6: fd10:0:2::1
 ```
 
 > **Note:** The IPv6 address for the VM and default gateway **must** be the ones

--- a/docs/network/interfaces_and_networks.md
+++ b/docs/network/interfaces_and_networks.md
@@ -196,7 +196,7 @@ properties "seen" inside guest instances, as listed below:
 |------------|--------------------------------------------------------------------|------------------------|--------------------------------------------------------------------------------------------|
 | model      | One of: `e1000`, `e1000e`, `ne2k_pci`, `pcnet`, `rtl8139`, `virtio`| `virtio`               | NIC type. **Note:** Use `e1000` model if your guest image doesn't ship with virtio drivers |
 | macAddress | `ff:ff:ff:ff:ff:ff` or `FF-FF-FF-FF-FF-FF`                         |                        | MAC address as seen inside the guest system, for example: `de:ad:00:00:be:af`              |
-| ports      |                                                                    | empty (i.e. all ports) | Allow-list of ports to be forwarded to the virtual machine                                 |
+| ports      |                                                                    | empty (i.e. all ports) | A list of ports to forward to the VM guest.                                                |
 | pciAddress | `0000:81:00.1`                                                     |                        | Set network interface PCI address, for example: `0000:81:00.1`                             |
 
 
@@ -215,7 +215,7 @@ spec:
               masquerade: {} # connect through a masquerade
               ports:
                - name: http
-                 port: 80 # allow only http traffic ingress
+                 port: 80 # forward only http traffic
       networks:
       - name: default
         pod: {}
@@ -267,13 +267,18 @@ spec:
 >
 ### Ports
 
-Declare ports listen by the virtual machine
+Declare ports to forward to the virtual machine guest.
 
 | Name       | 	Format   | 	Required | Description         |
 |------------|-----------|-----------|---------------------|
 | `name`     |           | no        | Name                |
 | `port`     | 1 - 65535 | yes       | Port to expose      |
 | `protocol` | TCP,UDP   | no        | Connection protocol |
+
+> **Note:**  
+> The `ports` attribute is only evaluated by specific network bindings, namely the masquerade core network binding.  
+> In the bridge network binding, it has no effect. For network binding plugins, its behavior depends on the plugin implementation.  
+> See the network binding plugin [documentation](https://kubevirt.io/user-guide/network/network_binding_plugins/) for details.
 
 If `spec.domain.devices.interfaces` is omitted, the virtual machine is
 connected using the default pod network interface of `bridge` type. If
@@ -386,7 +391,7 @@ spec:
             - name: red
               masquerade: {} # connect using masquerade mode
               ports:
-                - port: 80 # allow incoming traffic on port 80 to get into the virtual machine
+                - port: 80 # forward traffic on port 80 to the virtual machine guest
       networks:
       - name: red
         pod: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

The current documentation is incorrect. It indicates that the ports attribute  serves as some sort of firewall, when in fact is has a different effect on each  net binding. It is basically either a list of ports to forward or it has no effect   at all.


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
