### PR TITLE
chore(doc): document missing features in vmsnapshotrestores

### DIFF
--- a/docs/storage/clone_api.md
+++ b/docs/storage/clone_api.md
@@ -127,6 +127,35 @@ This field is used to explicitly set an SMBios serial for the target.
 
 This field is optional. By default, the target would have an auto-generated serial that's based on the VM name.
 
+### JSON patches
+
+It is sometimes necessary to modify the specs of VMs further than filtering before cloning them (e.g modifying or adding annotations for CNIs).
+
+JSON patches can be applied to the `specs` and `labels/annotations` of cloned VMs using the `patches` parameter:
+
+```yaml
+apiVersion: snapshot.kubevirt.io/v1beta1
+kind: VirtualMachineClone
+metadata:
+  name: cone
+spec:
+  source:
+    apiGroup: kubevirt.io
+    kind: VirtualMachine
+    name: vm-cirros
+  target:
+    apiGroup: kubevirt.io
+    kind: VirtualMachine
+    name: vm-clone-target
+  patches:
+    - '{"op": "add", "path": "/metadata/labels/test", "value": "something"}'
+    - '{"op": "replace", "path": "/spec/template/metadata/labels/example", "value": "replaced-value"}'
+```
+
+**Keep in mind that patches must be carefully applied.** Some fields might be used to reference other resources, or be used as targets by other resources.
+
+Patches are cumulative (and have precedence) with modifications done using template label/annotation filters and MAC address/SMBIOS fields.
+
 ### Creating a VirtualMachineClone object
 
 After the clone manifest is ready, we can create it:

--- a/docs/storage/snapshot_restore_api.md
+++ b/docs/storage/snapshot_restore_api.md
@@ -106,6 +106,41 @@ To wait for a restore to complete, execute:
 kubectl wait vmrestore restore-larry --for condition=Ready
 ```
 
+## Target readiness policies
+
+When restoring a `VirtualMachineSnapshot` on an already existing target (like the parent VM of the snapshot), a readiness policy can be specified to adjust how the restore happens if the target VM is not ready. The target VM is considered ready when it is fully stopped. The policy is controlled by setting `targetReadinessPolicy` to one of the available types.
+
+The following policies are available:
+- **WaitGracePeriod** (default policy): Wait 5 minutes for the target VM to be ready. If not ready in time, the restore will fail.
+- **StopTarget**: Stop the target VM so that the restore can continue immediately.
+- **FailImmediate**: Don't wait for the target to be ready before trying to restore. If it is not ready, the restore fails immediately.
+- **WaitEventually**: Kubevirt keeps the `VirtualMachineRestore` around until the target is ready. The restore is started as soon as the target is ready.
+
+## JSON patches
+
+It is sometimes necessary to modify the specs of VMs before restoring them (e.g modifying or adding annotations for CNIs).
+
+JSON patches can be applied to the `specs` and `labels/annotations` of restored VMs using the `patches` parameter:
+
+```yaml
+apiVersion: snapshot.kubevirt.io/v1beta1
+kind: VirtualMachineRestore
+metadata:
+  name: restore-larry
+spec:
+  target:
+    apiGroup: kubevirt.io
+    kind: VirtualMachine
+    name: larry
+  virtualMachineSnapshotName: snap-larry
+  patches:
+    - "{\"op\": \"replace\", \"path\": \"/spec/template/metadata/labels/example\", \"value\": \"replaced-value\"}" # Replace the content of a labels
+```
+
+Patches are only applied if the target is not an already existing VM.
+
+**Keep in mind that patches must be carefully applied.** Some fields might be used to reference other resources, or be used as targets by other resources.
+
 ## Cleanup
 
 Keep `VirtualMachineSnapshots` (and their corresponding `VirtualMachineSnapshotContents`) around as long as you may want to restore from them again.

--- a/docs/storage/snapshot_restore_api.md
+++ b/docs/storage/snapshot_restore_api.md
@@ -116,31 +116,6 @@ The following policies are available:
 - **FailImmediate**: Don't wait for the target to be ready before trying to restore. If it is not ready, the restore fails immediately.
 - **WaitEventually**: Kubevirt keeps the `VirtualMachineRestore` around until the target is ready. The restore is started as soon as the target is ready.
 
-## JSON patches
-
-It is sometimes necessary to modify the specs of VMs before restoring them (e.g modifying or adding annotations for CNIs).
-
-JSON patches can be applied to the `specs` and `labels/annotations` of restored VMs using the `patches` parameter:
-
-```yaml
-apiVersion: snapshot.kubevirt.io/v1beta1
-kind: VirtualMachineRestore
-metadata:
-  name: restore-larry
-spec:
-  target:
-    apiGroup: kubevirt.io
-    kind: VirtualMachine
-    name: larry
-  virtualMachineSnapshotName: snap-larry
-  patches:
-    - "{\"op\": \"replace\", \"path\": \"/spec/template/metadata/labels/example\", \"value\": \"replaced-value\"}" # Replace the content of a labels
-```
-
-Patches are only applied if the target is not an already existing VM.
-
-**Keep in mind that patches must be carefully applied.** Some fields might be used to reference other resources, or be used as targets by other resources.
-
 ## Cleanup
 
 Keep `VirtualMachineSnapshots` (and their corresponding `VirtualMachineSnapshotContents`) around as long as you may want to restore from them again.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

There's missing features in the documentation of VMRestores:
- target readiness policies
- patches

This was brought to my attention in this issue https://github.com/kubevirt/kubevirt/issues/14588 by @iholder101 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Now every feature available is documented:

```go
// VirtualMachineRestoreSpec is the spec for a VirtualMachineRestoreresource
type VirtualMachineRestoreSpec struct {
	// initially only VirtualMachine type supported
	Target corev1.TypedLocalObjectReference `json:"target"`

	VirtualMachineSnapshotName string `json:"virtualMachineSnapshotName"`

	// +optional
	TargetReadinessPolicy *TargetReadinessPolicy `json:"targetReadinessPolicy,omitempty"`

	// If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be
	// applied to the target manifest before it's created. Patches should fit the target's Kind.
	//
	// Example for a patch: {"op": "replace", "path": "/metadata/name", "value": "new-vm-name"}
	//
	// +optional
	// +listType=atomic
	Patches []string `json:"patches,omitempty"`
}
```

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
