### PR TITLE
Document how to run legacy Windows versions

### DIFF
--- a/docs/user_workloads/.pages
+++ b/docs/user_workloads/.pages
@@ -8,6 +8,7 @@ nav:
   - boot_from_external_source.md
   - startup_scripts.md
   - windows_virtio_drivers.md
+  - legacy_windows.md
   - Monitoring:
     - component_monitoring.md
     - guest_agent_information.md

--- a/docs/user_workloads/legacy_windows.md
+++ b/docs/user_workloads/legacy_windows.md
@@ -1,0 +1,38 @@
+# Running legacy Windows versions
+
+Legacy Windows versions like Windows XP or Windows Server 2003 are unable to
+boot on KubeVirt out of the box. This is due to the combination of the Q35
+machine-type and a 64-Bit PCI hole reported to the guest,
+that is not supported by these operating systems.
+
+To run legacy Windows versions on KubeVirt, reporting of the 64-Bit PCI hole
+needs to be disabled. This can be achieved by adding the
+`kubevirt.io/disablePCIHole64` annotation with a value of `true` to a
+`VirtualMachineInstance`'s annotations.
+
+## Example
+
+With this `VirtualMachine` definition a legacy Windows guest is able to boot:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: xp
+spec:
+  runStrategy: Always
+  template:
+    metadata:
+      annotations:
+        kubevirt.io/disablePCIHole64: "true"
+    spec:
+      domain:
+        devices: {}
+        memory:
+          guest: 512Mi
+      terminationGracePeriodSeconds: 180
+      volumes:
+      - containerDisk:
+          image: my/windowsxp:containerdisk
+        name: xp-containerdisk-0
+```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This adds documentation for the kubevirt.io/disablePCIHole64 annotation, that allows to run legacy Windows versions on KubeVirt.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
