### PR TITLE
CPU hotplug: Add net multi-queue limitation

### DIFF
--- a/docs/compute/cpu_hotplug.md
+++ b/docs/compute/cpu_hotplug.md
@@ -193,3 +193,14 @@ kubevirt-workload-update-cgdgd   Succeeded   vm-cirros
 * VPCU hotplug is currently not supported by ARM64 architecture.
 * Current hotplug implementation involves live-migration of the VM workload.
 
+### With NetworkInterfaceMultiQueue
+
+When a VM has VM.spec.template.spec.domain.devices.networkInterfaceMultiQueue set to `true`: 
+
+- On a CPU hotplug scenario, the VM owner will certainly gain the benefit of the additional vCPUs.
+However, any network interfaces that were already present before the CPU hotplug will retain their initial queue count.
+This is a characteristic of the underlying virtualization technology.
+- If the VM owner would like the network interface queue count to align with the new vCPU configuration to maximize performance, a restart of the VM will be required. Of course, this decision is entirely up to the VM owner.
+- Any new virtio network interfaces hotplugged after the CPU hotplug - will automatically have their queue count configured to match the updated vCPU configuration.
+
+> **Note:** This scenario is blocked in release-1.3 and release-1.2.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
PR kubevirt/kubevirt#14728, enabled CPU hotplug with network multi-queue.

The fix was backported to release-1.5 [1] and release-1.4 [2].

[1] https://github.com/kubevirt/kubevirt/pull/14762
[2] https://github.com/kubevirt/kubevirt/pull/14763

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
