### PR TITLE
net, hotplug: Add note about auto migration

### DIFF
--- a/docs/network/hotplug_interfaces.md
+++ b/docs/network/hotplug_interfaces.md
@@ -160,6 +160,11 @@ it's possible to hotplug an interface by migrating the VM.
 
 The actual attachment won't take place immediately, and the new interface will be available in the guest once the migration is completed.
 
+> **Note**: Starting with KubeVirt v1.6, virtual machines (VMs) will now automatically migrate following network interface card (NIC) 
+> hotplug or hot-unplug operations, provided the [LiveUpdate roll-out strategy](../user_workloads/vm_rollout_strategies.md#liveupdate) is configured on the KubeVirt Custom Resource (CR).
+> 
+> Manually migrating the VM in these scenarios is no longer required.
+
 ### Add new interface
 Add the desired interface and network to the VM spec template:
 ```yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Starting KubeVirt 1.6, the VM will be automatically migrated on hotplug and hot-unplug scenarios.

[1] https://github.com/kubevirt/kubevirt/pull/14259

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
