### PR TITLE
dns: Add note about ndots

### DIFF
--- a/docs/network/dns.md
+++ b/docs/network/dns.md
@@ -82,3 +82,9 @@ If no `spec.hostname` is set, then we fall back to the
 VirtualMachineInstance name itself. The resulting DNS A-record looks
 like this then:
 `<vmi.metadata.name>.<vmi.spec.subdomain>.<vmi.metadata.namespace>.svc.cluster.local`.
+
+Note:
+To resolve short names like `myvmi.mysubdomain` using search domains, 
+the guest's `/etc/resolv.conf` must include `options ndots:2` or higher.
+If the `options ndots` line is missing, the system defaults to `ndots:1`, 
+meaning search domains will not be applied to names containing a dot.


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Following https://github.com/kubevirt/kubevirt/issues/14934 We can see that when using subdomain,
`nslookup vmi.subdomain` won't resolve.
Reason is that despite virt-launcher has default k8s ndots:5, ndots option isn't populated to the guest, and depends on the local resolver.

If desired, cloud init can be used to override ndots.

      - cloudInitNoCloud:
          userData: |-
            #cloud-config
            bootcmd:
            - nmcli connection modify "System eth0" ipv4.dns-options "ndots:2"
            - nmcli connection up "System eth0"
        name: cloudinitdisk

Update docs about ndots effect.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
