### PR TITLE
net, istio: Deprecate annotation

### DIFF
--- a/docs/network/istio_service_mesh.md
+++ b/docs/network/istio_service_mesh.md
@@ -15,7 +15,7 @@ Kubevirt supports running VMs as a part of Istio service mesh.
 
 - This guide assumes that Istio is already deployed and uses Istio CNI Plugin. See [Istio documentation](https://istio.io/latest/docs/) for more information.
 
-- Optionally, `istioctl` binary for troubleshooting. See Istio [installation inctructions](https://istio.io/latest/docs/setup/getting-started/).
+- Optionally, `istioctl` binary for troubleshooting. See Istio [installation instructions](https://istio.io/latest/docs/setup/getting-started/).
 
 - The target namespace where the VM is created must be labelled with `istio-injection=enabled` label.
 
@@ -29,15 +29,14 @@ metadata:
 
 ## Create a VirtualMachineInstance with enabled Istio proxy injecton
 
-The example below specifies a VMI with masquerade network interface and `sidecar.istio.io/inject` annotation to register the VM to the service mesh. 
+The example below specifies a VMI with masquerade network interface and `sidecar.istio.io/inject` label to register the VM to the service mesh. 
 
 ```yaml
 apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
-  annotations:
-    sidecar.istio.io/inject: "true"
   labels:
+    sidecar.istio.io/inject: "true"
     app: vmi-istio
   name: vmi-istio
 spec:
@@ -79,7 +78,10 @@ spec:
       protocol: TCP
 ```
 
-**Note:** Each Istio enabled VMI must feature the `sidecar.istio.io/inject` annotation instructing KubeVirt to perform necessary network configuration.
+**Note:** Each Istio enabled VMI must feature the `sidecar.istio.io/inject` label instructing KubeVirt to perform necessary network configuration.
+
+**Note:** The `sidecar.istio.io/inject` VM/VMI annotation is deprecated in KubeVirt 1.7. in favor of a label of the same name.
+
 
 ## Verification
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
https://github.com/kubevirt/kubevirt/pull/15031 deprecates the VM/VMI annotation sidecar.istio.io/inject in favor of a label of the same name.
This follows Istio's own deprecation of the pod annotation in favor of a label.
Update docs to reflect change.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
