### PR TITLE
confidential computing: Add guide for running IBM Secure Execution VM

### DIFF
--- a/docs/cluster_admin/confidential_computing.md
+++ b/docs/cluster_admin/confidential_computing.md
@@ -65,3 +65,89 @@ spec:
 - SEV-encrypted VMs cannot contain directly-accessible host devices (that is, PCI passthrough)
 - Live Migration is not supported
 - The VMs are not attested
+
+## IBM Secure Execution for Linux (Secure Execution)
+
+**FEATURE STATE:** KubeVirt v1.6.0 (experimental support)
+
+IBM Secure Execution for Linux is a s390x security technology that is introduced with IBM z15 and LinuxONE III. It protects data of workloads that run in a KVM guest from being inspected or modified by the server environment.
+
+In particular, no hardware administrator, no KVM code, and no KVM administrator can access the data in a guest that was started as an IBM Secure Execution guest.
+
+For more details please read the [official documentation](https://www.ibm.com/docs/en/linux-on-systems?topic=execution-introduction).
+
+### Prerequisites
+
+- IBM z15/LinuxONE III or newer
+- Kubernetes Cluster with LPAR worker nodes (No nested virtualization)
+- Kubevirt and CDI deployed on the Cluster
+- `SecureExecution` [feature gate](../cluster_admin/activating_feature_gates.md#how-to-activate-a-feature-gate) must be enabled.
+- Secure Execution prepared guest. See the [official docs](https://www.ibm.com/docs/en/linux-on-systems?topic=execution-workload-owner-tasks).
+
+### Preparing the host(s)
+
+On all LPAR worker nodes that should run Secure Execution VMs, the following steps need to be taken to enable them to host the workloads:
+
+1. SSH to the node
+2. Add `prot_virt=1` to the kernel cmdline:
+  - Edit `zipl.conf`:
+  ```
+  # vi zipl.conf
+  ...
+  parameters=" ...prot_virt=1"
+  ...
+  ```
+  - Run `zipl` to ensure the change is picked up during the next reboot
+  - Reboot the node
+3. Verify that Secure Execution is now enabled:
+```
+$ cat /sys/firmware/uv/prot_virt_host
+1
+```
+
+### Running a Secure Execution Guest VM
+
+Ensure that your workload is [uploaded to a data volume using CDI](../storage/containerized_data_importer.md#virtctl-image-upload).
+
+Memory Protection via Secure Execution can be requested by setting `spec.domain.launchSecurity` element in the VMI definition.
+```
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  labels:
+    kubevirt.io/vm: secure-execution-vm
+  name: secure-execution-vm
+spec:
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: secure-execution-vm
+    spec:
+      domain:
+        launchSecurity: {}
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: rootfs
+        resources:
+          requests:
+            memory: 4Gi
+      terminationGracePeriodSeconds: 0
+      volumes:
+        - name: rootfs
+          dataVolume:
+            name: secure-execution-dv
+```
+### Limitations
+
+As the host is not permitted to access the guest memory, certain features do not work with Secure Execution VMs
+- live migration
+  - VMs need to be moved offline instead
+  - If moving between different machines, VMs need to be encrypted with hostkeys of both machines
+- Saving and restoring VM from disk
+- Memory dump
+- Huge Pages
+- Pass-through of host devices, for example PCI and CCW.
+- Memory ballooning through a virtio-balloon device.


### PR DESCRIPTION
Add guidance needed for running IBM Secure Execution VMs on s390x. Skip describing how to create the workload as this is specific to the user workload.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add guide to deploying Secure Execution VMs on s390x

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
