### PR TITLE
docs(compute): add storage config details to persistent_tpm_and_uefi_state.md

### DIFF
--- a/docs/compute/persistent_tpm_and_uefi_state.md
+++ b/docs/compute/persistent_tpm_and_uefi_state.md
@@ -45,6 +45,16 @@ spec:
             persistent: true
 ```
 
+For the persistent tpm volume to be created successfully you must ensure your storage classes and storage profiles are configured correctly.
+The persistent tpm volume will be created with the below access mode if one of the containts for the access mode is true.  
+RWX:  
+- the respective storage profile has any claim property set with RWX access mode
+- the kubevirt cluster config has `VMStateStorageClass` set and the storage profile does not exist or the storage profile exists but has no claim property sets
+
+RWO:  
+- the respective storage profile has only claim property sets with RWO access mode
+- the kubevirt cluster config has `VMStateStorageClass` unset and the storage profile does not exist or the storage profile exists but has no claim property sets
+
 ### Uses
 - The Microsoft Windows 11 installer requires the presence of a TPM device, even though it doesn't use this. Persistence is not required in this case however.
 - Some disk encryption software have optional/mandatory TPM support. For example, Bitlocker requires a persistent TPM device.

--- a/docs/compute/persistent_tpm_and_uefi_state.md
+++ b/docs/compute/persistent_tpm_and_uefi_state.md
@@ -45,8 +45,9 @@ spec:
             persistent: true
 ```
 
-For the persistent tpm volume to be created successfully you must ensure your storage classes and storage profiles are configured correctly.
+In order for the persistent tpm volume to be created successfully you must ensure your storage classes and storage profiles are configured correctly.  
 The persistent tpm volume will be created with the below access mode if one of the containts for the access mode is true.  
+
 RWX:  
 - the respective storage profile has any claim property set with RWX access mode
 - the kubevirt cluster config has `VMStateStorageClass` set and the storage profile does not exist or the storage profile exists but has no claim property sets


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds storage class and storage profile configuration details to the persistent tpm docs. This is needed so that users are aware of kubevirt persistent tpm volume defaulting and selection logic for access mode.  

My team had a use case where we had a 2 node cluster and were using the local path provisioner storage class which only works with a RWO access mode. It was difficult to understand why we never saw a persistent volume created until we dug into the kubevirt go source and realized how access mode is being calculated the VirtualMachine's persistent tpm volume.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
```
