### PR TITLE
docs(compute): update persistent_tpm_and_uefi_state.md

### DIFF
--- a/docs/compute/persistent_tpm_and_uefi_state.md
+++ b/docs/compute/persistent_tpm_and_uefi_state.md
@@ -50,12 +50,14 @@ In order for the persistent tpm volume to be created successfully you must ensur
 The persistent tpm volume will be created with the below access mode if one of the constraints for the access mode is true.
 
 * RWX (ReadWriteMany):
-    * the respective storage profile has any claim property set with Filesystem volume mode and RWX access mode.
-    * the kubevirt cluster config has `VMStateStorageClass` set and the storage profile does not exist or the storage profile exists but has no claim property sets.
+    * the respective storage profile has any `claimPropertySet` in `claimPropertySets` with Filesystem volume mode and RWX access mode.
+    * the kubevirt cluster config has `VMStateStorageClass` set and the storage profile does not exist.
+    * the kubevirt cluster config has `VMStateStorageClass` set and the storage profile exists but `claimPropertySets` is an empty list.
 
 * RWO (ReadWriteOnce):
-    * the respective storage profile has claim property sets with Filesystem volume mode and RWO access mode but not RWX.
-    * the kubevirt cluster config has `VMStateStorageClass` **unset** and the storage profile does not exist or the storage profile exists but has no claim property sets.
+    * the respective storage profile has `claimPropertySets` where all `claimPropertySet` in `claimPropertySets` have Filesystem volume mode and RWO access mode but not RWX.
+    * the kubevirt cluster config has `VMStateStorageClass` **unset** and the storage profile does not exist.
+    * the kubevirt cluster config has `VMStateStorageClass` **unset** and the storage profile exists but `claimPropertySets` is an empty list.
 
 ### Uses
 - The Microsoft Windows 11 installer requires the presence of a TPM device, even though it doesn't use this. Persistence is not required in this case however.

--- a/docs/compute/persistent_tpm_and_uefi_state.md
+++ b/docs/compute/persistent_tpm_and_uefi_state.md
@@ -45,6 +45,18 @@ spec:
             persistent: true
 ```
 
+
+In order for the persistent tpm volume to be created successfully you must ensure your storage classes and [storage profiles](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/storageprofile.md) are configured correctly.  
+The persistent tpm volume will be created with the below access mode if one of the constraints for the access mode is true.
+
+* RWX (ReadWriteMany):
+    * the respective storage profile has any claim property set with Filesystem volume mode and RWX access mode.
+    * the kubevirt cluster config has `VMStateStorageClass` set and the storage profile does not exist or the storage profile exists but has no claim property sets.
+
+* RWO (ReadWriteOnce):
+    * the respective storage profile has claim property sets with Filesystem volume mode and RWO access mode but not RWX.
+    * the kubevirt cluster config has `VMStateStorageClass` **unset** and the storage profile does not exist or the storage profile exists but has no claim property sets.
+
 ### Uses
 - The Microsoft Windows 11 installer requires the presence of a TPM device, even though it doesn't use this. Persistence is not required in this case however.
 - Some disk encryption software have optional/mandatory TPM support. For example, Bitlocker requires a persistent TPM device.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds storage class and storage profile configuration details to the persistent tpm docs. This is needed so that users are aware of kubevirt persistent tpm volume defaulting and selection logic for access mode.  

My team had a use case where we had a 2 node cluster and were using the local path provisioner storage class which only works with a RWO access mode. It was difficult to understand why we never saw a persistent volume created until we dug into the kubevirt go source (you can see the persistent tpm access mode logic [here](https://github.com/kubevirt/kubevirt/blob/v1.5.2/pkg/storage/backend-storage/backend-storage.go#L420)) and realized how access mode is being calculated for the VirtualMachine's persistent tpm volume.