### PR TITLE
accessing_virtual_machines: Remove virtctl local ssh flag

### DIFF
--- a/docs/user_workloads/accessing_virtual_machines.md
+++ b/docs/user_workloads/accessing_virtual_machines.md
@@ -258,8 +258,8 @@ a `VirtualMachineInstance` either from the CLI or a web-UI. The `VirtualMachine`
 subresource will automatically look up the corresponding `VirtualMachineInstance`.
 
 To connect to a `VirtualMachineInstance` from your local machine, `virtctl`
-provides an SSH client with the `ssh` command, that uses port
-forwarding. Refer to the command's help for more details.
+wraps the local SSH client with the `ssh` command and transparently uses port
+forwarding as described above. Refer to the command's help for more details.
 
 ```shell
 virtctl ssh
@@ -277,12 +277,11 @@ virtctl scp
 
 The preferred way of connecting to VMs and VMIs is to use `virtctl` to wrap
 local OpenSSH clients. If you prefer to use your local OpenSSH client directly
-instead, there are two ways of doing that in combination with `virtctl`.
+instead, there is also a way of doing that in combination with `virtctl`.
 
 > Note: Most of this applies to the `virtctl scp` command too.
 
-1. The `virtctl ssh` command has a `--local-ssh` option, which is set to `true` by
-   default. With this option, `virtctl` wraps the local OpenSSH client transparently
+1. By default `virtctl` wraps the local OpenSSH client transparently
    to the user. The executed SSH command can be viewed by increasing the verbosity (`-v 3`).
 
 ```shell


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

virtctl now only supports wrapping local ssh and scp clients. The --local-ssh flag was dropped, therefore remove it from the user guide.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/hold
Merge after https://github.com/kubevirt/kubevirt/pull/15478

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
