### PR TITLE
passt: Fix docs

### DIFF
--- a/docs/network/net_binding_plugins/passt.md
+++ b/docs/network/net_binding_plugins/passt.md
@@ -47,7 +47,7 @@ sysctl -w fs.file-max = 9223372036854775807
 > leading to memory overhead of up to 800 Mi.
 
 ## Passt network binding plugin
-[v1.1.0]
+[v1.6.0]
 
 The binding plugin replaces the experimental core passt binding implementation
 (including its API).
@@ -74,21 +74,59 @@ the passt plugin needs to:
 And in detail:
 
 ### Passt CNI deployment on nodes
-The CNI plugin binary can be retrieved directly from the kubevirt release
-assets (on GitHub) or to be built from its
-[sources](https://github.com/kubevirt/kubevirt/tree/release-1.1/cmd/cniplugins/passt-binding).
+Create the following DaemonSet:
 
-> **Note**: The kubevirt project uses Bazel to build the binaries and container images.
-> For more information in how to build the whole project, visit the developer
-> [getting started guide](https://github.com/kubevirt/kubevirt/blob/release-1.1/docs/getting-started.md).
-
-Once the binary is ready, you may rename it to a meaningful name
-(e.g. `kubevirt-passt-binding`).
-This name is used in the NetworkAttachmentDefinition configuration.
-
-Copy the binary to each node in your cluster.
-The location of the CNI plugins may vary between platforms and versions.
-One common path is `/opt/cni/bin/`.
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: passt-binding-cni
+  namespace: kubevirt
+  labels:
+    tier: node
+    app: passt-binding-cni
+spec:
+  selector:
+    matchLabels:
+      name: passt-binding-cni
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      labels:
+        name: passt-binding-cni
+        tier: node
+        app: passt-binding-cni
+      annotations:
+        description: passt-binding-cni installs 'passt binding' CNI on cluster nodes
+    spec:
+      priorityClassName: system-cluster-critical
+      containers:
+      - name: installer
+        image: quay.io/kubevirt/network-passt-binding-cni:v1.6.0
+        command: [ "/bin/sh", "-ce" ]
+        args:
+        - |
+          ls -la "/cni/kubevirt-passt-binding"
+          cp -f "/cni/kubevirt-passt-binding" "/opt/cni/bin"
+          echo "passt binding CNI plugin installation complete..sleep infinity"
+          sleep 2147483647
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "15Mi"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: cnibin
+          mountPath: /opt/cni/bin
+      volumes:
+      - name: cnibin
+        hostPath:
+          path: /opt/cni/bin
+```
 
 ### Passt NetworkAttachmentDefinition
 The configuration needed for passt is minimalistic:
@@ -97,11 +135,11 @@ The configuration needed for passt is minimalistic:
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
-  name: netbindingpasst
+  name: primary-udn-kubevirt-binding
 spec:
   config: '{
             "cniVersion": "1.0.0",
-            "name": "netbindingpasst",
+            "name": "primary-udn-kubevirt-binding",
             "plugins": [
               {
                 "type": "kubevirt-passt-binding"
@@ -124,13 +162,12 @@ The relevant sidecar image needs to be accessible by the cluster and
 specified in the Kubevirt CR when registering the network binding plugin.
 
 ### Feature Gate
-If not already set, add the `NetworkBindingPlugins` FG.
+If not already set, add the `PasstIPStackMigration` FG.
 ```
-kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-",   "value": "NetworkBindingPlugins"}]'
+kubectl patch kubevirt -n kubevirt kubevirt --type=merge -p='{"spec":{"configuration":{"developerConfiguration":{"featureGates":["PasstIPStackMigration"]}}}}'
 ```
 
-> **Note**: The specific passt plugin has no FG by its own. It is up to the cluster
-> admin to decide if the plugin is to be available in the cluster.
+> **Note**: It is up to the cluster admin to decide if the plugin is to be available in the cluster.
 > The passt binding is still in evaluation, use it with care.
 
 ### Passt Registration
@@ -142,12 +179,12 @@ To register the passt binding, patch the kubevirt CR as follows:
 kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "path": "/spec/configuration/network",   "value": {
             "binding": {
                 "passt": {
-                    "networkAttachmentDefinition": "default/netbindingpasst",
-                    "sidecarImage": "quay.io/kubevirt/network-passt-binding:20231205_29a16d5c9",
+                    "networkAttachmentDefinition": "default/primary-udn-kubevirt-binding",
+                    "sidecarImage": "quay.io/kubevirt/network-passt-binding:v1.6.0",
                     "migration": {},
                     "computeResourceOverhead": {
                       "requests": {
-                        "memory": "500Mi",
+                        "memory": "250Mi",
                       }
                     }
                 }
@@ -159,7 +196,7 @@ The NetworkAttachmentDefinition and sidecarImage values should correspond with t
 names used in the previous sections, [here](#passt-networkattachmentdefinition)
 and [here](#passt-sidecar-image).
 
-When using the plugin, additional memory overhead of `500Mi` will be requested for the compute container in the virt-launcher pod.
+When using the plugin, additional memory overhead of `250Mi` will be requested for the compute container in the virt-launcher pod.
 
 When the VM boots for the first time, Passt's internal DHCP server assigns an IP address to the guest with an "infinite" lease duration.
 
@@ -222,7 +259,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:v1.1.0
+          image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:v1.6.0
         name: containerdisk
       - cloudInitNoCloud:
           networkData: |


### PR DESCRIPTION
Update docs about cni daemonSet.
Update outdated parts.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
