### PR TITLE
Update network binding plugins documentation to reflect GA status

### DIFF
--- a/docs/network/net_binding_plugins/macvtap.md
+++ b/docs/network/net_binding_plugins/macvtap.md
@@ -121,14 +121,9 @@ exposed host interface (via the `lowerDevice` attribute, on the
 `macvtap-deviceplugin-config` `ConfigMap`).
 
 ## Macvtap network binding plugin
-[v1.1.1]
 
-The binding plugin replaces the experimental core macvtap binding implementation
-(including its API).
-
-> **Note**: The network binding plugin infrastructure and the macvtap plugin
-> specifically are in Alpha stage. Please use them with care, preferably
-> on a non-production deployment.
+> **Note**: The experimental core macvtap binding was deprecated in v1.2.0 and removed in v1.3.0. 
+> This documentation covers the **network binding plugin** implementation of macvtap.
 
 The macvtap binding plugin consists of the following components:
 
@@ -140,6 +135,10 @@ The plugin needs to:
 - Reference the network binding by name from the VM spec interface.
 
 And in detail:
+
+### Feature Gate
+As of v1.5.0, the Network Binding Plugin feature enabled by default and has no feature gate.
+The macvtap plugin similarly has no feature gate of its own, but the plugin needs to be made available in the cluster by [registering it](./#macvtap-registration).
 
 ### Macvtap Registration
 The macvtap binding plugin configuration needs to be added to the kubevirt CR

--- a/docs/network/net_binding_plugins/passt.md
+++ b/docs/network/net_binding_plugins/passt.md
@@ -43,9 +43,6 @@ Its main benefits are:
 The binding plugin replaces the experimental core passt binding implementation
 (including its API).
 
-> **Note**: The network binding plugin infrastructure and the passt plugin
-> specifically are in Alpha stage. Please use them with care, preferably
-> on a non-production deployment.
 
 The passt binding plugin consists of the following components:
 
@@ -171,6 +168,9 @@ The sidecar sources can be found
 The relevant sidecar image needs to be accessible by the cluster and
 specified in the Kubevirt CR when registering the network binding plugin.
 
+### Feature Gate
+As of v1.5.0, the Network Binding Plugin feature is enabled by default and has no feature gate.
+The passt plugin similarly has no feature gate of its own, but the plugin needs to be made available in the cluster by [registering it](./#passt-registration).
 
 ### Passt Registration
 As described in the [registration section](../../network/network_binding_plugins.md#register), passt binding plugin

--- a/docs/network/net_binding_plugins/slirp.md
+++ b/docs/network/net_binding_plugins/slirp.md
@@ -9,13 +9,13 @@ network connectivity.
 > UDP. ICMP is *not* supported.
 
 ## Slirp network binding plugin
-[v1.1.0]
+
+> **Important**: The core SLIRP binding was deprecated and removed in v1.3.0. 
+> This documentation covers the **network binding plugin** implementation of SLIRP.
 
 The binding plugin replaces the [core `slirp` binding](../../network/interfaces_and_networks.md#slirp)
 API.
 
-> **Note**: The network binding plugin infrastructure is in Alpha stage.
-> Please use them with care.
 
 The slirp binding plugin consists of the following components:
 
@@ -28,9 +28,13 @@ the slirp plugin needs to:
 - Register the binding plugin on the Kubevirt CR.
 - Reference the network binding by name from the VM spec interface.
 
-> **Note**: In order for the core slirp binding to use the network binding plugin
-> the registered name for this binding should be `slirp`.
+> **Note**: The registered name for this binding should be `slirp` to maintain
+> compatibility with existing VM specifications that reference the slirp binding.
 
+### Feature Gate
+As of v1.5.0, the Network Binding Plugin feature is enabled by default and has no feature gate.
+
+The slirp plugin similarly has no feature gate of its own, but the plugin needs to be made available in the cluster by [registering it](./#slirp-registration).
 
 ### Slirp Registration
 As described in the [registration section](../../network/network_binding_plugins.md#register), slirp binding plugin

--- a/docs/network/network_binding_plugins.md
+++ b/docs/network/network_binding_plugins.md
@@ -1,5 +1,4 @@
 # Network Binding Plugins
-[v1.4.0, Beta feature]
 
 A modular plugin which integrates with Kubevirt to implement a
 network binding.
@@ -57,9 +56,9 @@ and integrate it into Kubevirt in a modular manner.
 Kubevirt is providing several network binding plugins as references.
 The following plugins are available:
 
-- [passt](../network/net_binding_plugins/passt.md) [v1.1.0]
-- [macvtap](../network/net_binding_plugins/macvtap.md) [v1.1.1]
-- [slirp](../network/net_binding_plugins/slirp.md) [v1.1.0]
+- [passt](../network/net_binding_plugins/passt.md)
+- [macvtap](../network/net_binding_plugins/macvtap.md)
+- [slirp](../network/net_binding_plugins/slirp.md)
 
 ## Definition & Flow
 A network binding plugin configuration consist of the following steps:


### PR DESCRIPTION
- Update network binding plugins feature status from Beta to GA (v1.5.0)
- Remove version-specific tags from plugin listings
- Update passt, slirp, and macvtap plugin documentation:
  - Remove Alpha/Beta status warnings
  - Update feature gate requirements (now GA by default)
  - Clarify core binding vs plugin distinctions for slirp and macvtap
  - Add important notes about removed core bindings

Fixes: https://github.com/kubevirt/user-guide/issues/918

Additional context: 
* Robot 1 (NotebookLM) identified a list of 20+ inconsistencies between our release notes and our docs.
* Robot 2 (Claude) reviewed this list and compiled them into 8 issues. It then created this PR to resolve the first one. 
* Robot 3 (different Claude) reviewed the PR and picked up some nitpicks, some of which belonged to lines that no longer make sense within the GA context.
* Human author then reviewed all the changes in context (netlify build) and saw that a lot of these changes could be condensed, or were updates to things that could otherwise just be removed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
