### PR TITLE
Update VM lifecycle and node assignment docs: deprecate spec.running, document tolerations live update

### DIFF
--- a/docs/compute/node_assignment.md
+++ b/docs/compute/node_assignment.md
@@ -169,10 +169,13 @@ VirtualMachineInstance until the current instance of the VirtualMachineInstance 
 
 ## Live update
 
-When the [VM rollout strategy](../user_workloads/vm_rollout_strategies.md) is set to `LiveUpdate`, changes to a VM's
-node selector or affinities will dynamically propagate to the VMI (unless the `RestartRequired` condition is set).
-Changes to tolerations will not dynamically propagate, and will trigger a `RestartRequired` condition if changed on a
-running VM.
+
+When the [VM rollout strategy](../user_workloads/vm_rollout_strategies.md) is set to `LiveUpdate`, changes to a VM's node selector, affinities, and tolerations will dynamically propagate to the VMI (unless the `RestartRequired` condition is set).
+
+**Current behavior:**
+- Changes to tolerations are now supported for live update and will be applied to the running VMI without requiring a restart, as long as the `RestartRequired` condition is not set.
+
+Modifications of the node selector / affinities / tolerations will only take effect on next [migration](live_migration.md); the change alone will not trigger one.
 
 Modifications of the node selector / affinities will only take effect on next [migration](live_migration.md), the change
 alone will not trigger one.

--- a/docs/compute/run_strategies.md
+++ b/docs/compute/run_strategies.md
@@ -1,4 +1,8 @@
 # Run Strategies
+#
+> **⚠️ Deprecation Notice:**
+> 
+> The `spec.running` field is **deprecated** and should no longer be used to control VirtualMachine lifecycle. Use `spec.runStrategy` instead. Defining both `runStrategy` and `running` is **not allowed** and will be rejected by the API server. Always prefer `spec.runStrategy` for new and existing VirtualMachines.
 
 ## Overview
 
@@ -51,6 +55,11 @@ RunStrategies defined:
 *Note*: `RunStrategy` and `running` are mutually exclusive, because
 they can be contradictory. The API server will reject VirtualMachine
 resources that define both.
+
+> **Best Practice:**
+> - Use `spec.runStrategy` for all new and existing VirtualMachines.
+> - Do **not** use `spec.running`—it is deprecated and will be removed in future releases.
+> - Defining both fields is invalid and will be rejected.
 
 ### Virtctl
 


### PR DESCRIPTION
Resolves #923.


