### PR TITLE
Update instance types and preferences documentation for lifecycle changes

### DIFF
--- a/docs/compute/virtual_hardware.md
+++ b/docs/compute/virtual_hardware.md
@@ -43,7 +43,10 @@ wiki](https://wiki.qemu.org/Features/Q35).
 All virtual machines use BIOS by default for booting.
 
 It is possible to utilize UEFI/OVMF by setting a value via
-`spec.firmware.bootloader`:
+`spec.firmware.bootloader`.
+
+!!! Note
+    If you are using VirtualMachinePreferences to configure EFI settings, see the [Instance types and preferences](../user_workloads/instancetypes.md#deprecated-fields) documentation for information about the deprecated `PreferredUseEFi` and `PreferredUseSecureBoot` fields and their replacement with `PreferredEfi`.
 
 ```yaml
 apiVersion: kubevirt.io/v1


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add deprecation notices for PreferredUseEFi and PreferredUseSecureBoot fields (v1.5.0)
- Document PreferredEfi as the preferred replacement for EFI configuration
- Update ControllerRevision automatic upgrade behavior (v1.3.0)
- Note that manual revisionName removal is no longer required in most cases
- Update examples to use current best practices with PreferredEfi
- Add cross-reference in virtual_hardware.md for preference-based EFI configuration

Fixes: https://github.com/kubevirt/user-guide/issues/921

**Special notes for your reviewer**:

Created with Claude, from an issue that was created by a different Claude agent, from a list of inconsistencies generated from a comparison of the user-guide and the release notes.
Reviewed by human me prior to PR to pick up formatting, style, and redundancy issues. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
