### PR TITLE
docs (storage): Remove outdated virtiofs live migration restriction

### DIFF
--- a/docs/storage/volume_migration.md
+++ b/docs/storage/volume_migration.md
@@ -226,10 +226,10 @@ Users can find the whole list of migrated volumes in the VM status, which includ
 Only certain types of disks and volumes are supported to be migrated. For an invalid type of volume the RestartRequired condition is set and volumes will be replaced upon VM restart.
 Currently, the volume migration is supported between PersistentVolumeClaims and Datavolumes.
 Additionally, volume migration is forbidden if the disk is:
+
 * shareable, since it cannot guarantee the data consistency with multiple writers
-* hotpluggable, this case isn't currently supported
-* filesystem, since virtiofs doesn't currently support live-migration
-* lun, originally the disk might support SCSI protocol but the destination PVC class does not. This case isn't currently supported.
+* hotpluggable, this case is not currently supported
+* lun, originally the disk might support SCSI protocol but the destination PVC class does not. This case is not currently supported.
 
 Currently, KubeVirt only enables live migration between separate nodes. Volume migration relies on live migration; hence, live migrating storage on the same node is also not possible. Volume migration is possible between local storage, like between 2 PVCs with RWO access mode, but they need to be located on two different host.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Remove incorrect restriction that virtiofs does not support live migration as this was resolved in v1.5.0 (PR #13756)
- Fix markdown formatting for bullet point list rendering
- 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #922 

**Special notes for your reviewer**:

Created with Claude, from an issue that was created by a different Claude agent, from a list of inconsistencies generated from a comparison of the user-guide and the release notes.
Sceptical review of the issue revealed most of it was off track.
Al;so it looks as though a previous release note re: setting the `EnableVirtioFsPVC` featuregate was incorrect, which needs investigation.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
