### PR TITLE
Update hotplug_volumes.md

### DIFF
--- a/docs/storage/hotplug_volumes.md
+++ b/docs/storage/hotplug_volumes.md
@@ -33,7 +33,7 @@ The following table lists the minimum number of VirtIO ports that will be availa
 
 ## Declarative API
 
-Hotplug [DataVolume](./disks_and_volumes.md/#persistentvolumeclaim) and [PersistentVolumeClaim](./disks_and_volumes.md/#persistentvolumeclaim) volumes may be may be defined for VirtualMachines in a declarative, GitOps compatible way.
+Hotplug [DataVolume](./disks_and_volumes.md/#persistentvolumeclaim) and [PersistentVolumeClaim](./disks_and_volumes.md/#persistentvolumeclaim) volumes may be defined for VirtualMachines in a declarative, GitOps compatible way.
 
 ### Virtual Machine Definition
 


### PR DESCRIPTION
Fix duplicate 'may be' in hotplug_volumes.md
What this PR does / why we need it:Fixes a typo in docs/user-guide/storage/hotplug_volumes.md where "may be" was incorrectly duplicated as "may be may be defined". This correction improves documentation clarity and professionalism without altering the original meaning.
Which issue(s) this PR fixes:Fixes # (No existing issue, addressing a direct documentation typo)
Special notes for your reviewer:The typo is located in the "Declarative API" section. This PR only removes the redundant "may be" with no other content changes, ensuring minimal scope for review.
Checklist
This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.Approvers are expected to review this list.
- [  ]  Design: A design document was considered and is present (link) or not required
- [ √]  PR: The PR description is expressive enough and will help future contributors
- [  ]  Code: Write code that humans can understand and Keep it simple
- [√ ]  Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ]  Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ]  Testing: New code requires new unit tests. New features and bug fixes require at least on e2e test
- [√ ]  Documentation: A user-guide update was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ]  Community: Announcement to kubevirt-dev was considered
Release note:
NONE
