### PR TITLE
net, passt: Rm optimization requirements

### DIFF
--- a/docs/network/net_binding_plugins/passt.md
+++ b/docs/network/net_binding_plugins/passt.md
@@ -28,23 +28,11 @@ Its main benefits are:
 | Primary network (pod network)                  | Yes     |
 | Secondary network                              | No      |
 
-### Node optimization requirements/recommendations:
-
-1. To get better performance the node should be configured with:
-```
-sysctl -w net.core.rmem_max = 33554432
-sysctl -w net.core.wmem_max = 33554432
-```
-2. To run multiple passt VMs with no explicit ports, the node's `fs.file-max` should be increased
-   (for a VM forwards all IPv4 and IPv6 ports, for TCP and UDP, passt needs to create ~2^18 sockets):
-```
-sysctl -w fs.file-max = 9223372036854775807
-```
 
 > **NOTE**: To achieve optimal memory consumption with Passt binding,
 > specify ports required for your workload.
 > When no ports are explicitly specified, all ports are forwarded,
-> leading to memory overhead of up to 800 Mi.
+> leading to memory overhead of up to 250 Mi.
 
 ## Passt network binding plugin
 [v1.1.0]
@@ -124,7 +112,7 @@ The relevant sidecar image needs to be accessible by the cluster and
 specified in the Kubevirt CR when registering the network binding plugin.
 
 ### Feature Gate
-If not already set, add the `NetworkBindingPlugins` FG.
+For KubeVirt versions prior to v1.5, make sure to enable the `NetworkBindingPlugins` FG.
 ```
 kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-",   "value": "NetworkBindingPlugins"}]'
 ```
@@ -147,7 +135,7 @@ kubectl patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "add", "pat
                     "migration": {},
                     "computeResourceOverhead": {
                       "requests": {
-                        "memory": "500Mi",
+                        "memory": "250Mi",
                       }
                     }
                 }
@@ -159,7 +147,7 @@ The NetworkAttachmentDefinition and sidecarImage values should correspond with t
 names used in the previous sections, [here](#passt-networkattachmentdefinition)
 and [here](#passt-sidecar-image).
 
-When using the plugin, additional memory overhead of `500Mi` will be requested for the compute container in the virt-launcher pod.
+When using the plugin, additional memory overhead of `250Mi` will be requested for the compute container in the virt-launcher pod.
 
 When the VM boots for the first time, Passt's internal DHCP server assigns an IP address to the guest with an "infinite" lease duration.
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Remove redundant node optimization requirements which are no longer required, and update some stale information that is no longer relevant.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
