### PR TITLE
docs (user_workloads/monitoring): standardise format of code blocks for consistency

### DIFF
--- a/docs/user_workloads/component_monitoring.md
+++ b/docs/user_workloads/component_monitoring.md
@@ -21,31 +21,36 @@ The above labels and port informations are collected by a `Service`
 called `kubevirt-prometheus-metrics`. Kubernetes automatically creates a
 corresponding `Endpoint` with an equal name:
 
-    $ kubectl get endpoints -n kubevirt kubevirt-prometheus-metrics -o yaml
-    apiVersion: v1
-    kind: Endpoints
-    metadata:
-      labels:
-        kubevirt.io: ""
-        prometheus.kubevirt.io: ""
-      name: kubevirt-prometheus-metrics
+```bash
+kubectl get endpoints -n kubevirt kubevirt-prometheus-metrics -o yaml
+```
+
+```yaml
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    kubevirt.io: ""
+    prometheus.kubevirt.io: ""
+  name: kubevirt-prometheus-metrics
+  namespace: kubevirt
+subsets:
+- addresses:
+  - ip: 10.244.0.5
+    nodeName: node01
+    targetRef:
+      kind: Pod
+      name: virt-handler-cjzg6
       namespace: kubevirt
-    subsets:
-    - addresses:
-      - ip: 10.244.0.5
-        nodeName: node01
-        targetRef:
-          kind: Pod
-          name: virt-handler-cjzg6
-          namespace: kubevirt
-          resourceVersion: "4891"
-          uid: c67331f9-bfcf-11e8-bc54-525500d15501
-      - ip: 10.244.0.6
-      [...]
-      ports:
-      - name: metrics
-        port: 8443
-        protocol: TCP
+      resourceVersion: "4891"
+      uid: c67331f9-bfcf-11e8-bc54-525500d15501
+  - ip: 10.244.0.6
+  [...]
+  ports:
+  - name: metrics
+    port: 8443
+    protocol: TCP
+```
 
 By watching this endpoint for added and removed IPs to
 `subsets.addresses` and appending the `metrics` port from

--- a/docs/user_workloads/guest_agent_information.md
+++ b/docs/user_workloads/guest_agent_information.md
@@ -12,13 +12,14 @@ The condition tells that the GA is connected and can be used.
 
 GA condition on VirtualMachineInstance
 
-    status:
-      conditions:
-      - lastProbeTime: "2020-02-28T10:22:59Z"
-        lastTransitionTime: null
-        status: "True"
-        type: AgentConnected
-
+```yaml
+status:
+  conditions:
+  - lastProbeTime: "2020-02-28T10:22:59Z"
+    lastTransitionTime: null
+    status: "True"
+    type: AgentConnected
+```
 
 When the GA is connected, additional OS information is shown in the status.
 This information comprises:
@@ -30,24 +31,26 @@ Below is the example of the information shown in the VirtualMachineInstance stat
 
 GA info with merged into status
 
-    status:
-      guestOSInfo:
-        id: fedora
-        kernelRelease: 4.18.16-300.fc29.x86_64
-        kernelVersion: '#1 SMP Sat Oct 20 23:24:08 UTC 2018'
-        name: Fedora
-        prettyName: Fedora 29 (Cloud Edition)
-        version: "29"
-        versionId: "29"
-      interfaces:
-      - infoSource: domain, guest-agent
-        interfaceName: eth0
-        ipAddress: 10.244.0.23/24
-        ipAddresses:
-        - 10.244.0.23/24
-        - fe80::858:aff:fef4:17/64
-        mac: 0a:58:0a:f4:00:17
-        name: default
+```yaml
+status:
+  guestOSInfo:
+    id: fedora
+    kernelRelease: 4.18.16-300.fc29.x86_64
+    kernelVersion: '#1 SMP Sat Oct 20 23:24:08 UTC 2018'
+    name: Fedora
+    prettyName: Fedora 29 (Cloud Edition)
+    version: "29"
+    versionId: "29"
+  interfaces:
+  - infoSource: domain, guest-agent
+    interfaceName: eth0
+    ipAddress: 10.244.0.23/24
+    ipAddresses:
+    - 10.244.0.23/24
+    - fe80::858:aff:fef4:17/64
+    mac: 0a:58:0a:f4:00:17
+    name: default
+```
 
 When the Guest Agent is not present in the Virtual Machine, the Guest Agent information is not shown. No error is reported because the Guest Agent is an optional component.
 
@@ -76,74 +79,77 @@ The whole GA data is returned via `guestosinfo` subresource available behind the
 
 GuestOSInfo sample data:
 
-    {
-        "fsInfo": {
-            "disks": [
-                {
-                    "diskName": "vda1",
-                    "fileSystemType": "ext4",
-                    "mountPoint": "/",
-                    "totalBytes": 0,
-                    "usedBytes": 0
-                }
-            ]
-        },
-        "guestAgentVersion": "2.11.2",
-        "hostname": "testvmi6m5krnhdlggc9mxfsrnhlxqckgv5kqrwcwpgr5mdpv76grrk",
-        "metadata": {
-            "creationTimestamp": null
-        },
-        "os": {
-            "id": "fedora",
-            "kernelRelease": "4.18.16-300.fc29.x86_64",
-            "kernelVersion": "#1 SMP Sat Oct 20 23:24:08 UTC 2018",
-            "machine": "x86_64",
-            "name": "Fedora",
-            "prettyName": "Fedora 29 (Cloud Edition)",
-            "version": "29 (Cloud Edition)",
-            "versionId": "29"
-        },
-        "timezone": "UTC, 0"
-    }
+```json
+{
+    "fsInfo": {
+        "disks": [
+            {
+                "diskName": "vda1",
+                "fileSystemType": "ext4",
+                "mountPoint": "/",
+                "totalBytes": 0,
+                "usedBytes": 0
+            }
+        ]
+    },
+    "guestAgentVersion": "2.11.2",
+    "hostname": "testvmi6m5krnhdlggc9mxfsrnhlxqckgv5kqrwcwpgr5mdpv76grrk",
+    "metadata": {
+        "creationTimestamp": null
+    },
+    "os": {
+        "id": "fedora",
+        "kernelRelease": "4.18.16-300.fc29.x86_64",
+        "kernelVersion": "#1 SMP Sat Oct 20 23:24:08 UTC 2018",
+        "machine": "x86_64",
+        "name": "Fedora",
+        "prettyName": "Fedora 29 (Cloud Edition)",
+        "version": "29 (Cloud Edition)",
+        "versionId": "29"
+    },
+    "timezone": "UTC, 0"
+}
+```
 
 Items FSInfo and UserList are capped to the max capacity of 10 items, as a precaution for VMs with thousands of users.
 
 Full list of Filesystems is available through the subresource `filesystemlist` which is available as endpoint.
 
-
     /apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/filesystemlist
 
 Filesystem sample data:
 
-    {
-        "items": [
-            {
-                "diskName": "vda1",
-                "fileSystemType": "ext4",
-                "mountPoint": "/",
-                "totalBytes": 3927900160,
-                "usedBytes": 1029201920
-            }
-        ],
-        "metadata": {}
-    }
+```json
+{
+    "items": [
+        {
+            "diskName": "vda1",
+            "fileSystemType": "ext4",
+            "mountPoint": "/",
+            "totalBytes": 3927900160,
+            "usedBytes": 1029201920
+        }
+    ],
+    "metadata": {}
+}
+```
 
 Full list of the Users is available through the subresource `userlist` which is available as endpoint.
 
     /apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/userlist
 
-
-
 Userlist sample data:
 
-    {
-        "items": [
-            {
-                "loginTime": 1580467675.876078,
-                "userName": "fedora"
-            }
-        ],
-        "metadata": {}
-    }
+```json
+{
+    "items": [
+        {
+            "loginTime": 1580467675.876078,
+            "userName": "fedora"
+        }
+    ],
+    "metadata": {}
+}
+```
 
 User LoginTime is in fractional seconds since epoch time. It is left for the consumer to convert to the desired format.

--- a/docs/user_workloads/guest_operating_system_information.md
+++ b/docs/user_workloads/guest_operating_system_information.md
@@ -3,10 +3,12 @@
 Guest operating system identity for the VirtualMachineInstance will be
 provided by the label `kubevirt.io/os` :
 
-    metadata:
-      name: myvmi
-      labels:
-        kubevirt.io/os: win2k12r2
+```yaml
+metadata:
+  name: myvmi
+  labels:
+    kubevirt.io/os: win2k12r2
+```
 
 The `kubevirt.io/os` label is based on the short OS identifier from
 [libosinfo](https://libosinfo.org/) database. The following Short IDs
@@ -105,10 +107,12 @@ spec:
     - name: server2012r2
       persistentVolumeClaim:
         claimName: my-windows-image
+```
 
 Once the `VirtualMachineInstancePreset` is applied to the
 `VirtualMachineInstance`, the resulting resource would look like this:
 
+```yaml
 apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
@@ -193,7 +197,9 @@ spec:
 
 Alternatively, users can edit an existing kubevirt CR:
 
-`kubectl edit kubevirt kubevirt -n kubevirt`
+```bash
+kubectl edit kubevirt kubevirt -n kubevirt
+```
 
 ```yaml
 ...
@@ -203,4 +209,4 @@ spec:
       featureGates:
         - "HypervStrictCheck"
         - "CPUManager"
-```      
+```


### PR DESCRIPTION
**What this PR does / why we need it**:
I've started to improve the code block formatting, first starting with the section `user_workloads/monitoring` as a taster.

**Which issue(s) this PR fixes** *
Part of #896)  

**Special notes for your reviewer**:
 I've done this initial PR as I was unsure whether I should do one XL PR to cover everything or break things up - (I feel that XLs could maybe be inelegant). So looking for some guidance on that. I'm fine on either approach I just didn't want to impose initially. I feel a PR per each major docs section could work best.

I've built and tested these changes locally and all look good to me. 

FYI - @aburdenthehand 
