### PR TITLE
chore(virtiofs): Drop feature gate `EnableVirtioFsConfigVolumes`

### DIFF
--- a/docs/storage/disks_and_volumes.md
+++ b/docs/storage/disks_and_volumes.md
@@ -1001,8 +1001,6 @@ status: {}
 By using filesystem, `configMaps` are shared through `virtiofs`. In contrast with using disk for sharing `configMaps`,
 `filesystem` allows you to dynamically propagate changes on `configMaps` to VMIs (i.e. the VM does not need to be rebooted).
 
-> **Note:** You need to enable the feature gate `EnableVirtioFsConfigVolumes` for sharing `configMaps` with `virtiofs`.
-
 To share a given `configMap`, the following VM definition could be used:
 
 ```yaml
@@ -1127,8 +1125,6 @@ status: {}
 By using filesystem, `secrets` are shared through `virtiofs`. In contrast with using disk for sharing `secrets`,
 `filesystem` allows you to dynamically propagate changes on `secrets` to VMIs (i.e. the VM does not need to be rebooted).
 
-> **Note:** You need to enable the feature gate `EnableVirtioFsConfigVolumes` for sharing `secrets` with `virtiofs`.
-
 To share a given `secret`, the following VM definition could be used:
 
 ```yaml
@@ -1227,8 +1223,6 @@ spec:
 
 By using filesystem, `serviceAccounts` are shared through `virtiofs`. In contrast with using disk for sharing `serviceAccounts`,
 `filesystem` allows you to dynamically propagate changes on `serviceAccounts` to VMIs (i.e. the VM does not need to be rebooted).
-
-> **Note:** You need to enable the feature gate `EnableVirtioFsConfigVolumes` for sharing `serviceAccounts` with `virtiofs`.
 
 To share a given `serviceAccount`, the following VM definition could be used:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The feature has been graduated to GA. Therefore, the usage of the feature gate is not longer required to share configmaps, secrets, serviceAccounts or DownwardAPI with virtiofs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove `EnableVirtioFsConfigVolumes` feature gate references.
```
