### PR TITLE
Update confidential compute for AMD SEV-SNP

### DIFF
--- a/docs/cluster_admin/confidential_computing.md
+++ b/docs/cluster_admin/confidential_computing.md
@@ -66,6 +66,73 @@ spec:
 - Live Migration is not supported
 - The VMs are not attested
 
+## AMD Secure Encrypted Virtualization - Secure Nested Paging (SEV-SNP)
+
+**FEATURE STATE:** KubeVirt v1.7.0 (experimental support)
+
+
+KubeVirt supports running confidential VMs on AMD EPYC hardware with SEV-SNP support. 
+
+### Prerequisites
+
+- `WorkloadEncryptionSEV` [feature gate](../cluster_admin/activating_feature_gates.md#how-to-activate-a-feature-gate) must be enabled.
+- The guest must support [UEFI boot](../compute/virtual_hardware.md#biosuefi).
+- SecureBoot must be disabled for the guest VM.
+- AMD EPYC hardware that is capable of running [SEV-SNP](https://docs.amd.com/v/u/en-US/58207-using-sev-with-amd-epyc-processors).
+
+### Deploying AMD SEV-SNP enabled VMs
+
+SEV-SNP memory encryption can be requested by setting the `spec.domain.launchSecurity.snp` element in the VMI definition:
+
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstance
+metadata:
+  labels:
+    special: vmi-fedora
+  name: vmi-fedora
+spec:
+  domain:
+    launchSecurity:
+      snp: {}
+    firmware:
+      bootloader:
+        efi:
+          secureBoot: false
+    devices:
+      disks:
+      - disk:
+          bus: virtio
+        name: containerdisk
+      - disk:
+          bus: virtio
+        name: cloudinitdisk
+      rng: {}
+    resources:
+      requests:
+        memory: 1024M
+  terminationGracePeriodSeconds: 0
+  volumes:
+  - containerDisk:
+      image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
+    name: containerdisk
+  - cloudInitNoCloud:
+      userData: |-
+        #cloud-config
+        password: fedora
+        chpasswd: { expire: False }
+    name: cloudinitdisk
+```
+
+
+### Limitations
+
+- SEV/SEV-ES are mutually exclusive from SNP, running both SEV and SNP will not run.
+- Uses default policy that QEMU uses (e.g Policy: 0x30000).
+- Live Migration is not supported.
+- The VMs are not attested.
+
 ## IBM Secure Execution for Linux (Secure Execution)
 
 **FEATURE STATE:** KubeVirt v1.6.0 (experimental support)


### PR DESCRIPTION
Reflect new features added for AMD SEV-SNP

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Extends documentation for AMD SEV-SNP in the Confidential Compute section of the cluster administration. This will be needed for any users looking to use AMD SEV-SNP enabled Virtual Machines, this documentation is to give them a starting point on how to use this feature.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #940 

**Special notes for your reviewer**:
- The code for the new `launchsecurity.snp` was merged into main

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updated documentation for Confidential Compute to include AMD SEV-SNP support
```
