### PR TITLE
Fix Evict description formatting in KubeVirt updating_and_deletion documentation

### DIFF
--- a/docs/cluster_admin/updating_and_deletion.md
+++ b/docs/cluster_admin/updating_and_deletion.md
@@ -70,7 +70,7 @@ There are two methods supported.
 **LiveMigrate:** Which results in VMIs being updated by live migrating the
 virtual machine guest into a new pod with all the updated components enabled.
 
-**Evict: ** Which results in the VMI's pod being shutdown. If the VMI is
+**Evict:** Which results in the VMI's pod being shutdown. If the VMI is
 controlled by a higher level VirtualMachine object with `runStrategy: always`,
 then a new VMI will spin up in a new pod with updated components.
 


### PR DESCRIPTION
This PR fixes the formatting inconsistency where the "Evict" heading had different font styling compared to "LiveMigrate" in the [updating and deletion documentation](https://kubevirt.io/user-guide/cluster_admin/updating_and_deletion/).

Adjusted the markdown formatting for "Evict" to match the bold styling of "LiveMigrate", ensuring visual consistency in the document.
