### PR TITLE
Updated Mediated Devices docs to reflect deprecations.

### DIFF
--- a/docs/compute/mediated_devices_configuration.md
+++ b/docs/compute/mediated_devices_configuration.md
@@ -6,8 +6,8 @@ Administrators can use the `mediatedDevicesConfiguration` API in the KubeVirt CR
 create or remove mediated devices in a declarative way, by providing a list of the desired mediated device types that they expect to be configured in the cluster.
 
 You can also include the `nodeMediatedDeviceTypes` option to provide a more specific configuration that targets a specific node or a group of nodes directly with a node selector.
-The `nodeMediatedDeviceTypes` option must be used in combination with `mediatedDevicesTypes`
-in order to override the global configuration set in the `mediatedDevicesTypes` section.
+The `nodeMediatedDeviceTypes` option must be used in combination with `mediatedDeviceTypes`
+in order to override the global configuration set in the `mediatedDeviceTypes` section.
 
 KubeVirt will use the provided configuration to automatically create the relevant mdev/vGPU devices on nodes that can support it.
 
@@ -16,18 +16,18 @@ The maximum amount of instances of the selected mdev type will be configured per
 
 > Note: Some vendors, such as NVIDIA, require a driver to be installed on the nodes to provide mediated devices, including vGPUs.
 
-Example snippet of a KubeVirt CR configuration that includes both `nodeMediatedDeviceTypes` and `mediatedDevicesTypes`:
+Example snippet of a KubeVirt CR configuration that includes both `nodeMediatedDeviceTypes` and `mediatedDeviceTypes`:
 ```yaml
 spec:
   configuration:
     mediatedDevicesConfiguration:
-      mediatedDevicesTypes:
+      mediatedDeviceTypes:
       - nvidia-222
       - nvidia-228
       nodeMediatedDeviceTypes:
       - nodeSelector:
           kubernetes.io/hostname: nodeName
-        mediatedDevicesTypes:
+        mediatedDeviceTypes:
         - nvidia-234
 ```
 
@@ -42,7 +42,7 @@ For example, considering the following KubeVirt CR configuration:
 spec:
   configuration:
     mediatedDevicesConfiguration:
-      mediatedDevicesTypes:
+      mediatedDeviceTypes:
       - nvidia-222
       - nvidia-228
       - nvidia-105
@@ -85,15 +85,15 @@ For example, consider the following list of desired types, where nvidia-223 and 
 spec:
   configuration:
     mediatedDevicesConfiguration:
-      mediatedDevicesTypes:
+      mediatedDeviceTypes:
       - nvidia-223
       - nvidia-224
 ```
 In this case, nvidia-223 will be configured on the node because it is the first supported type in the list.
 
-## Overriding configuration on a specifc node
+## Overriding configuration on a specific node
 
-To override the global configuration set by `mediatedDevicesTypes`, include the `nodeMediatedDeviceTypes` option, specifying the node selector and the `mediatedDevicesTypes` that you want to override for that node.
+To override the global configuration set by `mediatedDeviceTypes`, include the `nodeMediatedDeviceTypes` option, specifying the node selector and the `mediatedDeviceTypes` that you want to override for that node.
 
 ### Example: Overriding the configuration for a specific node in a large cluster with multiple cards on each node
 
@@ -103,14 +103,14 @@ In this example, the KubeVirt CR includes the `nodeMediatedDeviceTypes` option t
 spec:
   configuration:
     mediatedDevicesConfiguration:
-      mediatedDevicesTypes:
+      mediatedDeviceTypes:
       - nvidia-230
       - nvidia-223
       - nvidia-224
     nodeMediatedDeviceTypes:
     - nodeSelector:
         kubernetes.io/hostname: node2  
-      mediatedDevicesTypes:
+      mediatedDeviceTypes:
       - nvidia-234
 ```
 
@@ -135,7 +135,7 @@ Node 1 has been configured in a round-robin manner based on the global configura
 
 ## Updating and Removing vGPU types
 
-Changes made to the `mediatedDevicesTypes` section of the KubeVirt CR will trigger a re-evaluation of the configured mdevs/vGPU types on the cluster nodes.
+Changes made to the `mediatedDeviceTypes` section of the KubeVirt CR will trigger a re-evaluation of the configured mdevs/vGPU types on the cluster nodes.
 
 Any change to the node labels that match the `nodeMediatedDeviceTypes` nodeSelector in the KubeVirt CR will trigger a similar re-evaluation.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
I updated the Mediated Devices documentation to reflect past deprecations. The current docs use `spec.configuration.mediatedDevicesConfiguration.mediatedDevicesTypes`, but the last property `mediatedDevicesTypes` has been deprecated.

In https://github.com/kubevirt/kubevirt/pull/8525, `mediatedDevicesTypes` was changed to `mediatedDeviceTypes` (singular Device). If you run the former old version, you get the following deprecation notice `'Warning: spec.configuration.mediatedDevicesConfiguration.mediatedDevicesTypes is deprecated, use mediatedDeviceTypes`.

Since the PR was merged 3+ years ago, the docs should be updated to reflect that.

**Special notes for your reviewer**:
None.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
