### PR TITLE
Clarify supported version update paths in documentation

### DIFF
--- a/docs/cluster_admin/updating_and_deletion.md
+++ b/docs/cluster_admin/updating_and_deletion.md
@@ -6,7 +6,11 @@ Zero downtime rolling updates are supported starting with release
 `v0.17.0` onward. Updating from any release prior to the KubeVirt
 `v0.17.0` release is not supported.
 
-> Note: Updating is only supported from N-1 to N release.
+> Note: Updating is only supported from N-1 to N release in the following form:
+> - Upgrading from one minor version to the next (for example, from v1.6.3 to v1.7.0).
+> - Upgrading to a later patch version (for example, from v1.6.2 to v1.6.3).
+> 
+> Not supported example: from v1.5.2 to v1.7.0
 
 Updates are triggered one of two ways.
 

--- a/docs/cluster_admin/updating_and_deletion.md
+++ b/docs/cluster_admin/updating_and_deletion.md
@@ -6,7 +6,22 @@ Zero downtime rolling updates are supported starting with release
 `v0.17.0` onward. Updating from any release prior to the KubeVirt
 `v0.17.0` release is not supported.
 
-> Note: Updating is only supported from N-1 to N release.
+!!! note "Supported Upgrade Paths"
+    Updating is only supported from N-1 to N release:
+
+    **Upgrading between minor versions:**
+
+    - Upgrade from the latest patch version of one minor version to the latest patch version of the next minor version
+    - Example: if latest 1.7 is v1.7.6 and latest 1.6 is v1.6.4
+        - ✓ Upgrade from v1.6.4 to v1.7.6 is supported
+        - ✗ Upgrade from v1.6.2 to v1.7.6 is not supported
+        - ✗ Upgrade from v1.5.z to v1.7.6 is not supported
+
+    **Upgrading within the same minor version:**
+
+    - Example: if latest 1.6 is v1.6.4 
+        - ✓ Upgrade from v1.6.3 to v1.6.4 is supported
+        - ✗ Upgrade from v1.6.2 to v1.6.4 is not supported
 
 Updates are triggered one of two ways.
 


### PR DESCRIPTION
This PR clarifies the supported version update paths in the KubeVirt documentation by expanding the upgrade support note with specific examples.

The previous note only stated "Updating is only supported from N-1 to N release" which was ambiguous. This update provides concrete examples showing:
- Minor version upgrades (e.g., from v1.6.3 to v1.7.0)
- Patch version upgrades (e.g., from v1.6.2 to v1.6.3)
- An example of what is NOT supported (e.g., from v1.5.2 to v1.7.0)

This makes it clearer for users to understand exactly which upgrade paths are supported when updating their KubeVirt installations.

**Release note**:
```release-note
NONE
```
