### PR TITLE
Update cpu_hotplug.md

### DIFF
--- a/docs/compute/cpu_hotplug.md
+++ b/docs/compute/cpu_hotplug.md
@@ -6,7 +6,7 @@ to allow for adding or removing virtual CPUs while the VM is running.
 ### Abstract
 A **virtual CPU** (vCPU) is the CPU that is seen to the Guest VM OS. A VM owner can manage the amount of vCPUs from the VM spec template using the CPU topology fields (`spec.template.spec.domain.cpu`). The `cpu` object has the integers `cores,sockets,threads` so that the virtual CPU is calculated by the following formula: `cores * sockets * threads`. 
 
-Before CPU hotplug was introduced, the VM owner could change these integers in the VM template while the VM is running, and they were staged until the next boot cycle. With CPU hotplug, it is possible to patch the `sockets` integer in the VM template and the change will take effect right away. 
+Before CPU hotplug was introduced, the VM owner could not change these integers in the VM template while the VM is running, and they were staged until the next boot cycle. With CPU hotplug, it is possible to patch the `sockets` integer in the VM template and the change will take effect right away. 
 
 Per each new socket that is hot-plugged, the amount of new vCPUs that would be seen by the guest is `cores * threads`, since the overall calculation of vCPUs is `cores * sockets * threads`. 
 

--- a/docs/compute/cpu_hotplug.md
+++ b/docs/compute/cpu_hotplug.md
@@ -6,7 +6,7 @@ to allow for adding or removing virtual CPUs while the VM is running.
 ### Abstract
 A **virtual CPU** (vCPU) is the CPU that is seen to the Guest VM OS. A VM owner can manage the amount of vCPUs from the VM spec template using the CPU topology fields (`spec.template.spec.domain.cpu`). The `cpu` object has the integers `cores,sockets,threads` so that the virtual CPU is calculated by the following formula: `cores * sockets * threads`. 
 
-Before CPU hotplug was introduced, the VM owner could not change these integers in the VM template while the VM is running, and they were staged until the next boot cycle. With CPU hotplug, it is possible to patch the `sockets` integer in the VM template and the change will take effect right away. 
+Before CPU hotplug was introduced, the VM owner could change these integers in the VM template while the VM was running but they would not take effect in the running VM until the next boot cycle. With CPU hotplug, it is possible to patch the `sockets` integer in the VM template and the change will take effect right away. 
 
 Per each new socket that is hot-plugged, the amount of new vCPUs that would be seen by the guest is `cores * threads`, since the overall calculation of vCPUs is `cores * sockets * threads`. 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
>> The documentation incorrectly describes the previous behaviour of vCPU hot plug. 

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
