### PR TITLE
docs, net, service-objects: Add a section for Service lifecycle

### DIFF
--- a/docs/network/service_objects.md
+++ b/docs/network/service_objects.md
@@ -178,3 +178,15 @@ Use `vinagre` client to connect your VirtualMachineInstance by using the
 public IP and port.
 
 Note that here the external port here (31829) was dynamically allocated.
+
+## Service lifecycle
+
+Service objects may be created explicitly by a user or implicitly
+through the `virtctl expose` command.
+
+While creating the service explicitly, it is up to the user to explicitly
+clean up the service.
+From v1.9 the implicit service creation through `virtctl expose` adds an
+[`ownerReference`](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/) to the service object, binding the service to the VM/VMI.
+As a result, the service will be collected by the k8s garbage-collector once
+the referenced object (e.g. VMI) is deleted.


### PR DESCRIPTION
**What this PR does / why we need it**:

In v1.9 `virtctl expose` adds a `ownerReference` to the Service object and binds it to the VM/VMI object.
Allowing proper cleanup of Services and avoiding orphan services.

This change complements https://github.com/kubevirt/kubevirt/pull/16884 by documenting it towards v1.9.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
