### PR TITLE
docs: add persistent vs ephemeral volumes comparison section

### DIFF
--- a/docs/storage/disks_and_volumes.md
+++ b/docs/storage/disks_and_volumes.md
@@ -729,6 +729,8 @@ conjunction with VirtualMachineInstanceReplicaSets.
 `containerDisks` are not a good solution for any workload that requires
 persistent root disks across VM restarts.
 
+If the disk must persist across VM restarts or stops, use a PVC or a [dataVolume](#datavolume) instead.
+
 #### containerDisk Workflow Example
 
 Users can inject a VirtualMachineInstance disk into a container image in


### PR DESCRIPTION
Resolves kubevirt/user-guide#949 by adding a clear explanation distinguishing DataVolumes (persistent) from ContainerDisks (ephemeral) in the Volumes section of disks_and_volumes.md.

**What this PR does / why we need it**:

This PR adds a new "Persistent vs Ephemeral Volumes" subsection under the `## Volumes` section in ```docs/storage/disks_and_volumes.md```. It provides a clear, concise explanation distinguishing between **DataVolumes** (persistent, PVC backed, for stateful workloads) and **ContainerDisks** (ephemeral, registry based, for stateless workloads). This helps new users quickly understand which volume type to use based on their workload requirements.

**Which issue(s) this PR fixes** 
Fixes #949

**Special notes for your reviewer**:

This is a documentation-only change. Only 7 lines were added under the existing `## Volumes` header, before the list of supported volume sources. No existing content was modified.

**Checklist**

- [x] Design: Not required (documentation-only change)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Not applicable (documentation-only change)
- [x] Refactor: Not applicable
- [x] Upgrade: No impact on upgrade flows
- [x] Testing: Not required (documentation-only change)
- [x] Documentation: This PR **is** the user-guide update
- [x] Community: Not required (minor docs improvement)

**Release note**:
```release-note
NONE
```