### PR TITLE
volume_migration: add the information about PVC support capability

### DIFF
--- a/docs/storage/volume_migration.md
+++ b/docs/storage/volume_migration.md
@@ -101,6 +101,48 @@ by updating the VM:
          name: datavolumedisk1
 ```
 
+### Using a PVC as the target volume
+
+Regular PVCs (not created via DataVolumes) are fully supported for volume migration. In this case, the volumes section references the PVC using `persistentVolumeClaim` instead of `dataVolume`.
+
+First, create the destination PVC:
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dst-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: rook-ceph
+```
+
+Then update the VM to migrate from the source DataVolume to the destination PVC:
+```diff
+ apiVersion: kubevirt.io/v1
+ kind: VirtualMachine
+     kubevirt.io/vm: vm-dv
+   name: vm-dv
+ spec:
++  updateVolumesStrategy: Migration
+-  dataVolumeTemplates:
+-  - metadata:
+-      name: src-dv
+-    spec:
+-      ...
+
+       volumes:
+-      - dataVolume:
+-          name: src-dv
++      - persistentVolumeClaim:
++          claimName: dst-pvc
+         name: datavolumedisk1
+```
+
 The destination volume may be of a different type or size than the source. It is possible to migrate from and to a block volume as well as a filesystem volume.
 The destination volume should be equal to or larger than the source volume. However, the additional difference in the size of the destination volume is not instantly visible within the VM and must be manually resized because the guest is unaware of the migration.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The current user guide did not mention any capability with PVC on volume migration.
Regular PVCs are fully supported for volume migration; we should expose this in the user guide.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
