### PR TITLE
net: Add live update NAD reference documentation

### DIFF
--- a/docs/network/hotplug/.pages
+++ b/docs/network/hotplug/.pages
@@ -1,3 +1,4 @@
 title: Hotplug
 nav:
   - interfaces.md
+  - nad_reference.md

--- a/docs/network/hotplug/nad_reference.md
+++ b/docs/network/hotplug/nad_reference.md
@@ -1,0 +1,106 @@
+# Live update NAD Reference
+
+Release:
+
+- v1.8.0: Beta
+- v1.9.0: GA (planned)
+
+KubeVirt supports updating the NetworkAttachmentDefinition (NAD) reference on a running Virtual Machine (VM) without requiring a reboot.
+This allows the user to change the network a VM is connected to by modifying the `networkName` field and waiting for a live migration of the VMI.
+
+This feature is useful when a VM needs to be moved between networks (e.g., different VLANs) while maintaining the same guest interface properties like name or MAC address.
+
+## Requirements
+
+To use this feature, the following requirements must be met:
+
+- The VM must be live-migratable
+- The `LiveUpdateNADRef` [feature-gate](https://kubevirt.io/user-guide/operations/activating_feature_gates/#how-to-activate-a-feature-gate) must be enabled (for v1.8 Beta release)
+- The target NetworkAttachmentDefinition must exist
+
+## Process of updating NAD Reference on a Running VM
+Current NAD
+```yaml
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: nad-with-vlan10
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "name": "nad-with-vlan10",
+    "type": "bridge",
+    "bridge": "br1",
+    "vlan": 10
+  }'
+```
+
+Target NAD
+```yaml
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: nad-with-vlan20
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "name": "nad-with-vlan20",
+    "type": "bridge",
+    "bridge": "br2",
+    "vlan": 20
+  }'
+```
+
+Start with a running VM connected to a secondary network attached to the current NAD:
+
+```yaml
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+...
+  template:
+    spec:
+      domain:
+        devices:
+          interfaces:
+          - bridge: {}
+            name: bridge-net
+...
+      networks:
+      - name: bridge-net
+        multus:
+          networkName: nad-with-vlan10
+...
+```
+
+To change the network, edit the VM spec template and update the `networkName` field:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+...
+  template:
+    spec:
+      domain:
+        devices:
+          interfaces:
+          - bridge: {}
+            name: bridge-net
+      networks:
+      - name: bridge-net
+        multus:
+          networkName: nad-with-vlan20  # Updated from nad-with-vlan10
+```
+
+This change will trigger a live migration which in turn creates a new pod connected to the new NAD.
+
+If automatic migration is not configured, a migration must be manually triggered.
+Please refer to the [Live Migration](../../compute/live_migration.md) documentation for more information.
+
+## Limitations
+- Moving to a different CNI type may fail, especially if the new CNI type requires additional configuration.
+- Switching to a new binding type/binding plugin is not supported.
+- Only migratable VMs can be updated as migration cannot be triggered on non migratable VMIs, which have `LiveMigratable`: `False` condition in their status.
+- Network connectivity may be interrupted during the live migration process.
+- When updating multiple VMs only a limited number of migrations run in parallel. So updates may be queued. For more information, see [Changing Cluster Wide Migration Configuration](../../compute/live_migration.md#changing-cluster-wide-migration-configuration).
+

--- a/docs/network/hotplug/nad_reference.md
+++ b/docs/network/hotplug/nad_reference.md
@@ -93,11 +93,10 @@ kind: VirtualMachine
 ```
 
 This change will trigger a live migration which in turn creates a new pod connected to the new NAD.
-
-If automatic migration is not configured, a migration must be manually triggered.
 Please refer to the [Live Migration](../../compute/live_migration.md) documentation for more information.
 
 ## Limitations
+- This feature is not supported with [Multus Dynamic networks Controller](https://github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller)
 - Moving to a different CNI type may fail, especially if the new CNI type requires additional configuration.
 - Switching to a new binding type/binding plugin is not supported.
 - Only migratable VMs can be updated as migration cannot be triggered on non migratable VMIs, which have `LiveMigratable`: `False` condition in their status.


### PR DESCRIPTION
Document the live update NAD reference feature which allows changing the NetworkAttachmentDefinition reference on running VMs through live migration without requiring a reboot.

VEP tracking issue: https://github.com/kubevirt/enhancements/issues/140

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
