### PR TITLE
docs: fix typos and grammar in launch-qemu-gdb.md

### DIFF
--- a/docs/debug_virt_stack/launch-qemu-gdb.md
+++ b/docs/debug_virt_stack/launch-qemu-gdb.md
@@ -1,6 +1,6 @@
 # Launch QEMU with gdb and connect locally with gdb client
 
-This guide is for cases where QEMU counters very early failures and it is hard to synchronize it in a later point in time.
+This guide is for cases where QEMU encounters very early failures and it is hard to synchronize it at a later point in time.
 
 ## Image creation and PVC population
 
@@ -35,13 +35,13 @@ RUN chown 107:107 ${DIR}/wrap_qemu_gdb.sh
 RUN chown 107:107 ${DIR}/logs
 ```
 
-Then, we can create and populate the `debug-tools` PVC as with did in the [strace example](../debug_virt_stack/launch-qemu-strace.md):
+Then, we can create and populate the `debug-tools` PVC as we did in the [strace example](../debug_virt_stack/launch-qemu-strace.md):
 ```console
 $ k apply -f debug-tools-pvc.yaml
 persistentvolumeclaim/debug-tools created
 $ kubectl  apply -f populate-job-pvc.yaml
 job.batch/populate-pvc created
-$ $ kubectl  get jobs
+$ kubectl  get jobs
 NAME           COMPLETIONS   DURATION   AGE
 populate-pvc   1/1           7s         2m12s
 ```
@@ -142,7 +142,7 @@ virt-launcher-vmi-debug-tools-tfh28   4/4     Running     0          25s
 ```
 
 
-The wrapping script starts the `gdbserver` and expose in the port `1234` inside the container. In order to be able to connect remotely to the gdbserver, we can use the command `kubectl port-forward` to expose the gdb port on our machine.
+The wrapping script starts the `gdbserver` and exposes port `1234` inside the container. In order to be able to connect remotely to the gdbserver, we can use the command `kubectl port-forward` to expose the gdb port on our machine.
 
 ```console
 $ kubectl  port-forward virt-launcher-vmi-debug-tools-tfh28 1234
@@ -151,7 +151,7 @@ Forwarding from [::1]:1234 -> 1234
 
 ```
 
-Finally, we can start the gbd client in the container:
+Finally, we can start the gdb client in the container:
 ```console
 $ podman run -ti --network host gdb-client:latest
 $ gdb /usr/libexec/qemu-kvm -ex 'target remote localhost:1234'


### PR DESCRIPTION
- Fix 'counters' -> 'encounters' and 'in a later' -> 'at a later'
- Fix 'as with did' -> 'as we did'
- Remove duplicate '$' in console snippet
- Fix 'expose in the port' -> 'exposes port'
- Fix typo 'gbd' -> 'gdb'

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
