### PR TITLE
Document RoleAggregationStrategy for opting out of RBAC aggregation

### DIFF
--- a/docs/cluster_admin/authorization.md
+++ b/docs/cluster_admin/authorization.md
@@ -63,27 +63,171 @@ role across all namespaces.
 With a RoleBinding, users receive the permissions granted by the role
 only within a targeted namespace.
 
-## Extending Kubernetes Default Roles with KubeVirt permissions
+## RBAC Role Aggregation
 
-The aggregated ClusterRole Kubernetes feature facilitates combining
-multiple ClusterRoles into a single aggregated ClusterRole. This feature
-is commonly used to extend the default Kubernetes roles with permissions
-to access custom resources that do not exist in the Kubernetes core.
+KubeVirt uses the Kubernetes
+[aggregated ClusterRoles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles)
+feature to automatically extend the default Kubernetes roles (`admin`,
+`edit`, `view`) with KubeVirt permissions. This means that by default,
+any user who already has one of these standard Kubernetes roles
+automatically receives the corresponding KubeVirt permissions within
+their namespace, without any additional configuration.
 
-In order to extend the default Kubernetes roles to provide permission to
-access KubeVirt resources, we need to add the following labels to the
-KubeVirt ClusterRoles.
+The mapping between KubeVirt ClusterRoles and Kubernetes default roles
+is:
 
-    kubectl label clusterrole kubevirt.io:admin rbac.authorization.k8s.io/aggregate-to-admin=true
-    kubectl label clusterrole kubevirt.io:edit rbac.authorization.k8s.io/aggregate-to-edit=true
-    kubectl label clusterrole kubevirt.io:view rbac.authorization.k8s.io/aggregate-to-view=true
+| KubeVirt ClusterRole | Aggregates to Kubernetes Role |
+|----------------------|-------------------------------|
+| `kubevirt.io:admin`  | `admin`                       |
+| `kubevirt.io:edit`   | `edit`                        |
+| `kubevirt.io:view`   | `view`                        |
 
-By adding these labels, any user with a RoleBinding or
-ClusterRoleBinding involving one of the default Kubernetes roles will
-automatically gain access to the equivalent KubeVirt roles as well.
+This aggregation is controlled by `aggregate-to-*` labels on the
+KubeVirt ClusterRoles (e.g.
+`rbac.authorization.k8s.io/aggregate-to-admin: "true"`).
 
-More information about aggregated cluster roles can be found
-[here](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles)
+### Controlling Role Aggregation Strategy
+
+> *NOTE* This feature is Alpha and requires the `OptOutRoleAggregation`
+> feature gate. It is available starting from KubeVirt v1.8.
+
+While automatic RBAC aggregation is convenient for many deployments,
+security-conscious environments may require more granular control over
+permissions. KubeVirt provides the `roleAggregationStrategy` field in
+the KubeVirt CR configuration, which allows cluster administrators to
+opt out of automatic aggregation.
+
+The `roleAggregationStrategy` field accepts two values:
+
+- **`AggregateToDefault`** (default): KubeVirt ClusterRoles are
+  aggregated to the default Kubernetes roles. Users with the standard
+  `admin`, `edit`, or `view` roles automatically receive the
+  corresponding KubeVirt permissions. This is the default behavior when
+  the field is not set.
+
+- **`Manual`**: KubeVirt ClusterRoles are **not** aggregated to the
+  default Kubernetes roles. Users must be granted KubeVirt permissions
+  explicitly through dedicated RoleBindings or ClusterRoleBindings.
+
+#### Enabling Manual Role Aggregation
+
+To use the `Manual` strategy, first enable the `OptOutRoleAggregation`
+feature gate, then set `roleAggregationStrategy` to `Manual`:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+metadata:
+  name: kubevirt
+  namespace: kubevirt
+spec:
+  configuration:
+    developerConfiguration:
+      featureGates:
+        - OptOutRoleAggregation
+    roleAggregationStrategy: Manual
+```
+
+See [Activating feature gates](activating_feature_gates.md) for more
+details on enabling feature gates.
+
+> *NOTE* Setting `roleAggregationStrategy` to `Manual` without enabling
+> the `OptOutRoleAggregation` feature gate will be rejected by the
+> admission webhook. The value `AggregateToDefault` (or leaving the
+> field unset) does not require the feature gate.
+
+#### Re-enabling Aggregation
+
+To restore the default aggregation behavior, set `roleAggregationStrategy`
+to `AggregateToDefault` or remove the field entirely:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+metadata:
+  name: kubevirt
+  namespace: kubevirt
+spec:
+  configuration:
+    roleAggregationStrategy: AggregateToDefault
+```
+
+The change takes effect on the next reconciliation cycle without
+requiring a KubeVirt reinstallation.
+
+#### Behavior Summary
+
+| Configuration | Fresh Install | Existing Install |
+|---------------|---------------|------------------|
+| `AggregateToDefault` or unset | ClusterRoles created with aggregate labels | Aggregate labels restored if previously removed |
+| `Manual` (with feature gate) | ClusterRoles created without aggregate labels | Aggregate labels removed from existing ClusterRoles |
+
+#### Granting Permissions with Manual Strategy
+
+When `roleAggregationStrategy` is set to `Manual`, users with the
+standard Kubernetes `admin`, `edit`, or `view` roles will **not**
+automatically receive KubeVirt permissions. Instead, cluster
+administrators must explicitly bind the KubeVirt ClusterRoles to users
+or groups.
+
+**Granting full KubeVirt admin permissions in a single namespace:**
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubevirt-admin
+  namespace: my-namespace
+subjects:
+  - kind: User
+    name: jane
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: kubevirt.io:admin
+  apiGroup: rbac.authorization.k8s.io
+```
+
+**Granting view-only access across all namespaces:**
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-viewers
+subjects:
+  - kind: Group
+    name: vm-viewers
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: kubevirt.io:view
+  apiGroup: rbac.authorization.k8s.io
+```
+
+**Granting edit access to a group in a specific namespace:**
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubevirt-editors
+  namespace: dev-team
+subjects:
+  - kind: Group
+    name: developers
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: kubevirt.io:edit
+  apiGroup: rbac.authorization.k8s.io
+```
+
+> *NOTE* Regardless of the `roleAggregationStrategy` setting, all
+> authenticated users retain read access to the KubeVirt CR itself
+> (`get`, `list` on `kubevirts.kubevirt.io`). This is granted by the
+> **kubevirt.io:default** ClusterRole, which is bound to the
+> `system:authenticated` group and is not affected by role aggregation.
 
 ## Creating Custom RBAC Roles
 
@@ -97,7 +241,7 @@ like. A custom RBAC role can be created by reducing the permissions in
 this example role.
 
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: my-custom-rbac-role


### PR DESCRIPTION
- Update the authorization page to document the new `roleAggregationStrategy` configuration field (Alpha, behind `OptOutRoleAggregation` feature gate), which allows cluster administrators to opt out of automatic RBAC role
  aggregation to the default Kubernetes `admin`, `edit`, and `view` roles
- Replace the outdated "Extending Kubernetes Default Roles" section (which instructed users to manually label ClusterRoles) with an accurate description of KubeVirt's automatic aggregation behavior
- Add examples for granting KubeVirt permissions explicitly when using the `Manual` strategy (RoleBinding and ClusterRoleBinding)
- Fix deprecated `rbac.authorization.k8s.io/v1beta1` apiVersion in the custom RBAC role example

Relates to kubevirt/kubevirt#16350 (VEP 160)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Document RoleAggregationStrategy for opting out of RBAC aggregation
```
