### PR TITLE
net: add DRA SR-IOV user guide

### DIFF
--- a/docs/network/.pages
+++ b/docs/network/.pages
@@ -1,5 +1,6 @@
 nav:
   - dns.md
+  - dra_sriov.md
   - interfaces_and_networks.md
   - istio_service_mesh.md
   - network_binding_plugins.md

--- a/docs/network/dra_sriov.md
+++ b/docs/network/dra_sriov.md
@@ -1,0 +1,104 @@
+# DRA-based SR-IOV for Virtual Machines
+
+[v1.9] - Alpha
+
+This guide shows how to connect a VM to an SR-IOV network using Kubernetes DRA (Dynamic Resource Allocation).
+In this model, SR-IOV devices are requested through `ResourceClaim` APIs and attached through KubeVirt `resourceClaim` networks.
+
+## Before you begin
+
+- Enable and configure an external SR-IOV DRA driver in the cluster.
+- Ensure a matching `DeviceClass` exists for SR-IOV devices.
+- Enable the `NetworkDevicesWithDRA` KubeVirt feature gate.
+- Use Kubernetes v1.36 or newer (required for DRA device metadata file support).
+
+!!! warning
+    In Alpha, DRA-based SR-IOV and legacy device-plugin SR-IOV are mutually exclusive at cluster level.
+    Use a single SR-IOV mode per cluster.
+
+## 1) Enable the KubeVirt feature gate
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+metadata:
+  name: kubevirt
+  namespace: kubevirt
+spec:
+  configuration:
+    developerConfiguration:
+      featureGates:
+      - NetworkDevicesWithDRA
+```
+
+For more details, see [Activating and deactivating feature gates](../cluster_admin/activating_feature_gates.md).
+
+## 2) Create network and claim objects
+
+Create a `NetworkAttachmentDefinition` used by SR-IOV CNI:
+
+```yaml
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-nad
+spec:
+  config: |
+    {
+      "cniVersion": "0.4.0",
+      "name": "sriov-nad",
+      "type": "sriov",
+      "ipam": { "type": "host-local", "ranges": [[{"subnet":"10.0.1.0/24"}]] }
+    }
+```
+
+Create a `ResourceClaimTemplate` that requests an SR-IOV VF from DRA:
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: sriov-claim-template
+spec:
+  spec:
+    devices:
+      requests:
+      - name: vf
+        exactly:
+          deviceClassName: sriovnetwork.k8snetworkplumbingwg.io
+      config:
+      - requests: ["vf"]
+        opaque:
+          driver: sriovnetwork.k8snetworkplumbingwg.io
+          parameters:
+            apiVersion: sriovnetwork.k8snetworkplumbingwg.io/v1alpha1
+            kind: VfConfig
+            netAttachDefName: sriov-nad
+            driver: vfio-pci
+            addVhostMount: true
+```
+
+## 3) Attach the DRA SR-IOV network to a VMI
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstance
+metadata:
+  name: vmi-sriov-dra
+spec:
+  domain:
+    devices:
+      interfaces:
+      - name: sriov-net
+        sriov: {}
+  networks:
+  - name: sriov-net
+    resourceClaim:
+      claimName: sriov-network-claim
+      requestName: vf
+  resourceClaims:
+  - name: sriov-network-claim
+    resourceClaimTemplateName: sriov-claim-template
+```
+
+The `networks[].resourceClaim.claimName` must match `spec.resourceClaims[].name`, and `requestName` must match the request in the claim (`vf` in this example).

--- a/docs/network/interfaces_and_networks.md
+++ b/docs/network/interfaces_and_networks.md
@@ -27,10 +27,11 @@ a unique name.
 Each network should declare its type by defining one of the following
 fields:
 
-| Type     | Description                                                                                  |
-|----------|----------------------------------------------------------------------------------------------|
-| `pod`    | Default Kubernetes network                                                                   |
-| `multus` | Secondary network provided using Multus or Primary network when Multus is defined as default |
+| Type            | Description                                                                                  |
+|-----------------|----------------------------------------------------------------------------------------------|
+| `pod`           | Default Kubernetes network                                                                   |
+| `multus`        | Secondary network provided using Multus or Primary network when Multus is defined as default |
+| `resourceClaim` | Secondary network backed by Kubernetes DRA `ResourceClaim` APIs                              |
 
 ### pod
 
@@ -506,6 +507,8 @@ The device is passed through into the guest operating system as a [host
 device](https://libvirt.org/drvnodedev.html), using the
 [vfio](https://www.kernel.org/doc/Documentation/vfio.txt) userspace
 interface, to maintain high networking performance.
+
+For DRA-based SR-IOV configuration (alpha), see [DRA-based SR-IOV for Virtual Machines](./dra_sriov.md).
 
 #### How to expose SR-IOV VFs to KubeVirt
 To simplify procedure, use the [SR-IOV network operator](https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/v1.4.0/doc/quickstart.md) to deploy


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Document the alpha DRA-based SR-IOV flow so VM owners can wire 
ResourceClaims to SR-IOV interfaces with a minimal, working setup.

Also link the new guide from network navigation and the interfaces 
reference to make the DRA path discoverable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
