### PR TITLE
feat: Document GuestAgentPing probe pausing via annotation (VEP 207)

### DIFF
--- a/docs/user_workloads/liveness_and_readiness_probes.md
+++ b/docs/user_workloads/liveness_and_readiness_probes.md
@@ -367,3 +367,46 @@ incoming qemu-ga commands:
 ```sh
 journalctl _COMM=qemu-ga --follow
 ```
+
+## Pausing Guest-Agent Ping Probes
+
+During maintenance operations such as guest OS updates (especially long Windows
+updates with multiple reboots), the guest agent may become temporarily
+unavailable. If a GuestAgentPing liveness probe is configured, this will cause
+the probe to fail and kubelet to restart the Pod, destroying the running VM.
+
+To prevent this, you can pause GuestAgentPing probes by adding an annotation
+to the VMI:
+
+```bash
+# Pause probes before maintenance
+kubectl annotate vmi my-vm kubevirt.io/pause-guest-agent-probes=true
+
+# Resume probes after maintenance
+kubectl annotate vmi my-vm kubevirt.io/pause-guest-agent-probes-
+```
+
+When the annotation is set to a truthy value (`"true"`, `"1"`, `"t"`, etc. as
+accepted by Go's `strconv.ParseBool`), virt-launcher returns immediate success
+for GuestAgentPing probes without contacting the QEMU guest agent. Removing the
+annotation (or setting it to a falsy value) resumes normal probe behavior.
+
+To verify that virt-launcher has picked up the annotation, check its logs for
+the state transition message:
+
+```bash
+kubectl logs -n <namespace> virt-launcher-my-vm-<id> -c compute | grep "probe pause state"
+```
+
+!!! important
+    - This annotation only affects GuestAgentPing probes. HTTP, TCP, and exec
+      probes are not affected.
+    - The annotation takes effect within seconds (on the next virt-launcher
+      sync cycle, triggered by virt-handler).
+    - For permanent probe disabling, remove the probe from the VMI spec instead
+      of keeping the annotation set indefinitely.
+    - Internal probe suppression for transient states (e.g., live migration,
+      VM pause) is handled automatically and independently of the annotation.
+      Setting the annotation to `"false"` or removing it will not override
+      internal suppression — probes remain suppressed during these operations
+      regardless of the annotation value.


### PR DESCRIPTION
Do not merge until https://github.com/kubevirt/kubevirt/pull/17664 is merged
**What this PR does / why we need it**:
Add documentation for the new kubevirt.io/pause-guest-agent-probes annotation that allows users to temporarily pause GuestAgentPing probes during maintenance operations such as guest OS updates. Covers usage instructions (pause, check status, resume) and important caveats including that the annotation is not intended for permanent probe disabling.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
feat: Document GuestAgentPing probe pausing via annotation (VEP 207)
```
