### PR TITLE
confidential computing: Update IBM Secure Execution feature state

### DIFF
--- a/docs/cluster_admin/confidential_computing.md
+++ b/docs/cluster_admin/confidential_computing.md
@@ -71,7 +71,7 @@ spec:
 **FEATURE STATE:** KubeVirt v1.7.0 (experimental support)
 
 
-KubeVirt supports running confidential VMs on AMD EPYC hardware with SEV-SNP support. 
+KubeVirt supports running confidential VMs on AMD EPYC hardware with SEV-SNP support.
 
 ### Prerequisites
 
@@ -135,21 +135,25 @@ spec:
 
 ## IBM Secure Execution for Linux (Secure Execution)
 
-**FEATURE STATE:** KubeVirt v1.6.0 (experimental support)
-
 IBM Secure Execution for Linux is a s390x security technology that is introduced with IBM z15 and LinuxONE III. It protects data of workloads that run in a KVM guest from being inspected or modified by the server environment.
 
 In particular, no hardware administrator, no KVM code, and no KVM administrator can access the data in a guest that was started as an IBM Secure Execution guest.
 
 For more details please read the [official documentation](https://www.ibm.com/docs/en/linux-on-systems?topic=execution-introduction).
 
+### **FEATURE STATE:**
+
+* Alpha - [`v1.6.0`](https://github.com/kubevirt/kubevirt/releases/tag/v1.6.0)
+* Beta - [`v1.7.0`](https://github.com/kubevirt/kubevirt/releases/tag/v1.7.0)
+* GA - [`v1.9.0`](https://github.com/kubevirt/kubevirt/releases/tag/v1.9.0) (Enabled by default)
+
 ### Prerequisites
 
 - IBM z15/LinuxONE III or newer
 - Kubernetes Cluster with LPAR worker nodes (No nested virtualization)
 - Kubevirt and CDI deployed on the Cluster
-- `SecureExecution` [feature gate](../cluster_admin/activating_feature_gates.md#how-to-activate-a-feature-gate) must be enabled.
 - Secure Execution prepared guest. See the [official docs](https://www.ibm.com/docs/en/linux-on-systems?topic=execution-workload-owner-tasks).
+- Before kubevirt 1.9: `SecureExecution` [feature gate](../cluster_admin/activating_feature_gates.md#how-to-activate-a-feature-gate) must be enabled.
 
 ### Preparing the host(s)
 


### PR DESCRIPTION
Add GA state to IBM Secure Execution feature.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update the feature state description for IBM Secure Execution to reflect the graduation with 1.9
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
VEP: https://github.com/kubevirt/enhancements/issues/19

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
