### PR TITLE
Add cloud-init example for guest DNS resolver configuration

### DIFF
--- a/docs/network/dns.md
+++ b/docs/network/dns.md
@@ -86,3 +86,22 @@ like this then:
 > **Note** To resolve short names like `myvmi.mysubdomain` using search domains, the guest's `/etc/resolv.conf` must include `options ndots:2` or higher.
 > In a Linux guest if `options ndots` is not specified, the system defaults to `ndots:1` as indicated in  resolver spec](https://man7.org/linux/man-pages/man5/resolv.conf.5.html).
 > KubeVirt does not configure the guest system resolver. It can either be pre-configured in the VM image or configured at runtime using cloud-init.
+
+Example using cloud-init to configure the guest resolver:
+
+```yaml
+- cloudInitNoCloud:
+    userData: |
+      #cloud-config
+      write_files:
+        - path: /etc/systemd/resolved.conf.d/dns.conf
+          content: |
+            [Resolve]
+            DNS=<cluster-dns-service-ip>
+            Domains=default.svc.cluster.local svc.cluster.local cluster.local
+      runcmd:
+        - systemctl restart systemd-resolved
+  name: cloudinitdisk
+```
+
+The exact DNS service IP depends on the Kubernetes cluster configuration.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR improves the DNS records documentation by adding a practical cloud-init example for configuring the guest DNS resolver.

The current documentation explains the requirement for `options ndots:2` or higher when resolving short names such as `myvmi.mysubdomain`, but it does not provide an example on how to configure the guest operating system.

The added example demonstrates how to configure DNS settings using cloud-init in a persistent and systemd-resolved friendly way.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Special notes for your reviewer**:

This is a documentation-only improvement.

**Checklist**

* [x] Design: not required
* [x] PR: The PR description is expressive enough and will help future contributors
* [x] Code: not applicable
* [x] Refactor: not applicable
* [x] Upgrade: not applicable
* [x] Testing: not applicable
* [x] Documentation: user-guide update included
* [x] Community: not required

**Release note**:

```release-note
NONE
```
