### PR TITLE
Update feature gates doc for beta-on-by-default (VEP 229)

### DIFF
--- a/docs/cluster_admin/activating_feature_gates.md
+++ b/docs/cluster_admin/activating_feature_gates.md
@@ -4,14 +4,52 @@ KubeVirt has a set of features that are not mature enough to be enabled by
 default. As such, they are protected by a Kubernetes concept called
 [feature gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/).
 
-## List of feature gates
-The list of feature gates (which evolve in time) can be checked directly from
-the [source code](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-config/featuregate/active.go) (use the const string values in the yaml configuration).
+## Feature gate lifecycle
+
+KubeVirt features progress through maturity stages, each with different
+default behavior:
+
+| Stage | Default state | How to change |
+|---|---|---|
+| **Alpha** | Disabled | Enable via `featureGates` |
+| **Beta** | Enabled (from v1.9) | Disable via `disabledFeatureGates` |
+| **GA** | Always enabled | Cannot be disabled |
+
+- **Alpha** features are experimental and must be explicitly enabled.
+  They may be incomplete, have breaking API changes, or be removed
+  entirely.
+- **Beta** features are considered stable enough for broad testing.
+  Starting from KubeVirt v1.9, all Beta feature gates are
+  **enabled by default**. See
+  [VEP 229: Beta features on by default](https://github.com/kubevirt/enhancements/blob/main/veps/meta-VEPs/229-beta-features-on-by-default/vep.md)
+  and the [blog post](https://kubevirt.io/2026/Beta-Features-On-By-Default-In-v1-9.html)
+  for full details.
+- **GA** features are always enabled and cannot be toggled. The
+  feature gate itself is considered obsolete at this stage.
+
+## Feature gate report
+
+Starting from v1.9, KubeVirt ships a **feature gate report** as
+part of every release's artifacts. This JSON file lists every non-GA
+feature gate and its current state (Alpha, Beta, or Deprecated).
+
+You can find it in the
+[release artifacts](https://github.com/kubevirt/kubevirt/releases)
+for each version, or generate it yourself from a KubeVirt source
+tree:
+
+```bash
+make feature-gate-report
+```
+
+The full list of feature gates can also be checked directly from the
+[source code](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-config/featuregate/active.go).
 
 ## How to activate a feature gate
-You can activate a specific feature gate directly in KubeVirt's CR, by
-provisioning the following yaml, which uses the `ExperimentalFeatureToEnable` feature gate
-as an example:
+
+Alpha features must be explicitly enabled. You can activate a feature
+gate in KubeVirt's CR:
+
 ```bash
 cat << END > enable-feature-gate.yaml
 ---
@@ -24,13 +62,14 @@ spec:
   configuration:
     developerConfiguration:
       featureGates:
-        - ExperimentalFeatureToEnable
+        - AlphaFeatureToEnable
 END
 
 kubectl apply -f enable-feature-gate.yaml
 ```
 
-Alternatively, the existing kubevirt CR can be altered:
+Alternatively, edit the existing KubeVirt CR:
+
 ```bash
 kubectl edit kubevirt kubevirt -n kubevirt
 ```
@@ -41,20 +80,28 @@ spec:
   configuration:
     developerConfiguration:
       featureGates:
-        - ExperimentalFeatureToEnable
+        - AlphaFeatureToEnable
 ```
 
 **Note:** the name of the feature gates is case sensitive.
 
-The snippet above assumes KubeVirt is installed in the `kubevirt` namespace.
-Change the namespace to suite your installation.
+The snippets above assume KubeVirt is installed in the `kubevirt`
+namespace. Change the namespace to suit your installation.
 
 ## How to disable a feature gate
 
-Starting from KubeVirt v1.8, you can explicitly disable feature gates using the `disabledFeatureGates` field.
-This is particularly useful when you want to disable beta features that may be enabled by default.
+Starting from KubeVirt v1.8, you can explicitly disable feature gates
+using the `disabledFeatureGates` field. From v1.9, this is the
+only way to opt out of Beta features that are enabled by
+default.
 
-To disable specific feature gates, add them to the `disabledFeatureGates` list:
+**It is recommended to disable all Beta feature gates in production**
+unless you have explicitly validated them for your environment. Use
+the feature gate report from the release artifacts to
+programmatically populate this list.
+
+To disable specific feature gates, add them to the
+`disabledFeatureGates` list:
 
 ```bash
 cat << END > disable-feature-gate.yaml
@@ -66,11 +113,9 @@ metadata:
   namespace: kubevirt
 spec:
   configuration:
-    developerConfiguration: 
-      featureGates:
-        - ExperimentalFeatureToEnable
+    developerConfiguration:
       disabledFeatureGates:
-        - ExperimentalFeatureToDisable
+        - BetaFeatureToDisable
 END
 
 kubectl apply -f disable-feature-gate.yaml
@@ -87,13 +132,22 @@ kubectl edit kubevirt kubevirt -n kubevirt
 spec:
   configuration:
     developerConfiguration:
-      featureGates:
-        - ExperimentalFeatureToEnable
       disabledFeatureGates:
-        - ExperimentalFeatureToDisable
+        - BetaFeatureToDisable
 ```
 
 !!! warning "Important"
-    A feature gate cannot be listed in both `featureGates` and `disabledFeatureGates` at the same time.
-    This will result in a validation error.
+    A feature gate cannot be listed in both `featureGates` and
+    `disabledFeatureGates` at the same time. This will result in a
+    validation error.
 
+## Upgrade considerations
+
+When upgrading to v1.9 or later, be aware that all Beta features
+will become active by default. Review the feature gate report for
+the target version and configure `disabledFeatureGates` as needed.
+
+The `disabledFeatureGates` mechanism was introduced in v1.8. If
+you are upgrading from v1.7 or older directly to v1.9, Beta
+features will be unconditionally enabled until you patch the
+KubeVirt CR post-upgrade. Upgrading to v1.8 first is recommended.


### PR DESCRIPTION
**What this PR does / why we need it**:
Rewrite the feature gates documentation to reflect that starting from v1.9, all Beta feature gates are enabled by default. Add feature gate lifecycle table, feature gate report section, production recommendation to disable Beta features, and upgrade considerations.

VEP tracking issue: https://github.com/kubevirt/enhancements/issues/229.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update feature gates doc for beta-on-by-default (VEP 229)
```
