### PR TITLE
Document VMI memory overhead status reporting

### DIFF
--- a/docs/compute/resources_requests_and_limits.md
+++ b/docs/compute/resources_requests_and_limits.md
@@ -61,7 +61,45 @@ metadata:
 
 ## Memory
 ### Memory requests on the container
-- VM(I)s must specify a desired amount of memory, in either spec.domain.memory.guest or spec.domain.resources.requests.memory (ignoring hugepages, see the [dedicated page](../compute/hugepages.md)). If both are set, the memory requests take precedence. A calculated amount of overhead will be added to it, forming the memory request value for the container.
+- VM(I)s must specify a desired amount of memory, in either spec.domain.memory.guest or spec.domain.resources.requests.memory (ignoring hugepages, see the [dedicated page](../compute/hugepages.md)). If both are set, the memory requests take precedence. A calculated amount of overhead will be added to it, forming the memory request value for the container. See [Memory Overhead](../compute/virtual_hardware.md#memory-overhead) for what contributes to that overhead.
+
+### Viewing memory overhead
+
+> Note: This feature requires the `VmiMemoryOverheadReport` feature gate to be enabled.
+
+When the feature gate is enabled, the calculated overhead is exposed in
+the VMI status:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstance
+metadata:
+  name: my-vmi
+status:
+  memory:
+    memoryOverhead: 512Mi
+```
+
+The `status.memory.memoryOverhead` field is populated when the VMI
+starts, and reflects the overhead calculated for the current
+virt-launcher pod.
+
+#### Memory overhead after live migration
+
+During live migration, the target node may calculate a different
+overhead value (for example, due to different hardware or configuration).
+While a migration is in progress, the target overhead is reported in
+`status.migrationState.targetMemoryOverhead`. Once the migration
+completes, `status.memory.memoryOverhead` is updated to reflect the
+new value:
+
+```yaml
+status:
+  memory:
+    memoryOverhead: 520Mi
+  migrationState:
+    targetMemoryOverhead: 520Mi
+```
 
 ### Memory limits on the container
 - By default, no memory limit is set on the container

--- a/docs/compute/resources_requests_and_limits.md
+++ b/docs/compute/resources_requests_and_limits.md
@@ -61,9 +61,24 @@ metadata:
 
 ## Memory
 ### Memory requests on the container
-- VM(I)s must specify a desired amount of memory, in either spec.domain.memory.guest or spec.domain.resources.requests.memory (ignoring hugepages, see the [dedicated page](../compute/hugepages.md)). If both are set, the memory requests take precedence. A calculated amount of overhead will be added to it, forming the memory request value for the container. See [Memory Overhead](../compute/virtual_hardware.md#memory-overhead) for what contributes to that overhead.
+- VM(I)s must specify a desired amount of memory, in either spec.domain.memory.guest or spec.domain.resources.requests.memory (ignoring hugepages, see the [dedicated page](../compute/hugepages.md)). If both are set, the memory requests take precedence. A calculated amount of overhead will be added to it, forming the memory request value for the container. See [Memory overhead](#memory-overhead) below for what contributes to that overhead.
 
-### Viewing memory overhead
+### Memory overhead
+
+Various VM resources, such as a video adapter, IOThreads, and
+supplementary system software, consume additional memory from the Node,
+beyond the requested memory intended for the guest OS consumption. In
+order to provide a better estimate for the scheduler, this memory
+overhead will be calculated and added to the requested memory.
+
+The default memory overhead has been set to 32Mi to account for these
+additional system resources.
+
+Please see [how Pods with resource requests are
+scheduled](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-requests-are-scheduled)
+for additional information on resource requests and limits.
+
+#### Viewing memory overhead
 
 > Note: This feature requires the `VmiMemoryOverheadReport` feature gate to be enabled.
 

--- a/docs/compute/virtual_hardware.md
+++ b/docs/compute/virtual_hardware.md
@@ -740,6 +740,11 @@ overhead will be calculated and added to the requested memory.
 The default memory overhead has been set to 32Mi to account for these
 additional system resources.
 
+When the `VmiMemoryOverheadReport` feature gate is enabled, the overhead
+applied to a running VMI is reported in
+`status.memory.memoryOverhead`. See [Viewing memory
+overhead](../compute/resources_requests_and_limits.md#viewing-memory-overhead).
+
 Please see [how Pods with resource requests are
 scheduled](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-requests-are-scheduled)
 for additional information on resource requests and limits.

--- a/docs/compute/virtual_hardware.md
+++ b/docs/compute/virtual_hardware.md
@@ -729,26 +729,6 @@ competition for CPU resources.
 For more information please refer to [how Pods with resource limits are
 run](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-limits-are-run).
 
-### Memory Overhead
-
-Various VM resources, such as a video adapter, IOThreads, and
-supplementary system software, consume additional memory from the Node,
-beyond the requested memory intended for the guest OS consumption. In
-order to provide a better estimate for the scheduler, this memory
-overhead will be calculated and added to the requested memory.
-
-The default memory overhead has been set to 32Mi to account for these
-additional system resources.
-
-When the `VmiMemoryOverheadReport` feature gate is enabled, the overhead
-applied to a running VMI is reported in
-`status.memory.memoryOverhead`. See [Viewing memory
-overhead](../compute/resources_requests_and_limits.md#viewing-memory-overhead).
-
-Please see [how Pods with resource requests are
-scheduled](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-requests-are-scheduled)
-for additional information on resource requests and limits.
-
 ### Hugepages
 
 KubeVirt give you possibility to use hugepages as backing memory for


### PR DESCRIPTION
Add docs for status.memory.memoryOverhead behind the VmiMemoryOverheadReport feature gate, including live migration behavior, under resources requests and limits and link from the virtual hardware memory overhead section.


Enhancement link: https://github.com/kubevirt/enhancements/blob/main/veps/sig-compute/156-vmi-memory-overhead-reporting/vmi-memory-overhead-reporting.md

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Document VMI memory overhead status reporting
```
