### PR TITLE
Add documentation for when live migration is multithreaded

### DIFF
--- a/docs/compute/live_migration.md
+++ b/docs/compute/live_migration.md
@@ -264,6 +264,7 @@ the VM the guest executes on). There are many reasons for migrations to fail con
 high dirty-rate or low resources like network bandwidth and CPU. On such scenarios, see the following
 alternative strategies below.
 
+For virtual machines that explicitly set resource limits, multithreaded migration is disabled and single-threaded migration will be used instead.
 ### Post-copy
 The way post-copy migrations work is as following:
 

--- a/docs/compute/live_migration.md
+++ b/docs/compute/live_migration.md
@@ -264,7 +264,7 @@ the VM the guest executes on). There are many reasons for migrations to fail con
 high dirty-rate or low resources like network bandwidth and CPU. On such scenarios, see the following
 alternative strategies below.
 
-For virtual machines that explicitly set resource limits, multithreaded migration is disabled and single-threaded migration will be used instead.
+For virtual machines that explicitly set CPU resource limits, multithreaded migration is disabled and single-threaded migration will be used instead.
 ### Post-copy
 The way post-copy migrations work is as following:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
this explicitly documents that VMs with explicitly defined cpu limits (not ones created by the autocpulimits feature) will not go through parallel live migration as per [this line of code ](https://github.com/kubevirt/kubevirt/blob/913717faa83bbe8ca6b588c2ee14a5ed465757cf/pkg/virt-handler/migration-source.go#L639).

