### PR TITLE
missing docs: unprivileged_userfaultfd requirement for postcopy

### DIFF
--- a/docs/compute/live_migration.md
+++ b/docs/compute/live_migration.md
@@ -25,6 +25,10 @@ field in the KubeVirt CR must be expanded by adding the `LiveMigration` to it.
 
 - Live migration requires the virt-launcher pod's primary network interface to have the same name on both source and target pods.
 
+- Post-copy live migration requires additional node-level permissions on
+  most environments. See [Node configuration for post-copy](#node-configuration-for-post-copy)
+  for details.
+
 ## Initiate live migration
 
 Live migration is initiated by posting a VirtualMachineInstanceMigration
@@ -223,6 +227,7 @@ To configure `AllowWorkloadDisruption`:
 
 - `AllowWorkloadDisruption` determines whether the migration controller can prioritize completing the migration over avoiding workload disruption.
 - Post-copy migration, when enabled, poses some risk of data loss if a failure occurs during the post-copy phase.
+- Post-copy requires additional node-level permissions on most environments. See [Node configuration for post-copy](#node-configuration-for-post-copy) for details.
 - Pausing the workload facilitates completion of the migration without risk of data loss but may result in temporary workload inactivity.
 
 
@@ -296,6 +301,68 @@ example, if either the target or guest VMs crash the state cannot be recovered.
 the guest would have to wait for a lot of memory in a short period of time.
 * Slower than pre-copy on most cases.
 * Harder to cancel a migration.
+
+#### Node configuration for post-copy
+
+Post-copy migration uses the `userfaultfd` syscall on the target node to
+fetch memory pages on demand from the source. Because the QEMU process
+runs unprivileged, additional permissions may be required depending on
+your environment.
+
+##### Kernel sysctl
+
+The following sysctl must be enabled on every node that may receive a
+post-copy migration:
+
+```
+vm.unprivileged_userfaultfd=1
+```
+
+Supported versions of OpenShift/OKD already set this sysctl via the Machine Config
+Operator, so no action is needed there. On other Kubernetes
+distributions, persist the setting by adding the line to a file such as
+`/etc/sysctl.d/99-postcopy.conf` either manually or using your cluster's node
+configuration tooling (e.g. cloud-init, Ansible, or a DaemonSet).
+
+!!! warning
+    Enabling `vm.unprivileged_userfaultfd` allows VM processes to use the
+    `userfaultfd` syscall. Some security-hardened kernels disable it by
+    default.
+
+##### Seccomp
+
+On clusters where seccomp is enforced, container runtimes such as CRI-O
+may block `userfaultfd` by default. The `KubevirtSeccompProfile`
+[feature gate](../cluster_admin/activating_feature_gates.md#how-to-activate-a-feature-gate)
+installs a seccomp profile that permits this syscall. This feature gate
+reached Beta in KubeVirt v1.7, but Beta feature gates are only enabled by
+default since v1.9 — on older versions it must be enabled explicitly.
+
+In addition to the feature gate, the KubeVirt CR must be configured to
+use the custom profile:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: Kubevirt
+metadata:
+  name: kubevirt
+  namespace: kubevirt
+spec:
+  configuration:
+    seccompConfiguration:
+      virtualMachineInstanceProfile:
+        customProfile:
+          localhostProfile: kubevirt/kubevirt.json
+```
+
+##### SELinux
+
+On nodes with SELinux enforcing, the virt-launcher process may be
+denied `userfaultfd` depending on the `container_t` policy in use.
+Nodes running `container-selinux` v2.248 or later already include the
+necessary permission (`kernel_userfaultfd_use(container_domain)`). On
+older versions, administrators may need to create a custom SELinux
+policy module to permit this syscall for the relevant context.
 
 ### Auto-converge
 Auto-converge is a technique to help pre-copy migrations converge faster without changing the core


### PR DESCRIPTION
**What this PR does / why we need it**:

On most modern distros, vm.unprivileged_userfaultfd is disabled by default preventing QEMU from capturing page faults during a postcopy migration on the receiving node. However this requirement is currently not documented anywhere.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt/issues/17780

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
