### PR TITLE
docs: Template Beta graduation, OCI export

### DIFF
--- a/docs/storage/export_api.md
+++ b/docs/storage/export_api.md
@@ -66,6 +66,31 @@ spec:
 
 When you create a VMExport based on a Virtual Machine Snapshot, the controller will attempt to create PVCs from the volume snapshots contained in Virtual Machine Snapshot. Once all the PVCs are ready, the export server will start and you can begin the export. If the Virtual Machine Snapshot contains multiple volumes that can be exported, each volume will get its own URL links. If the Virtual Machine snapshot contains no volumes that can be exported, the VMExport will go into a `skipped` phase, and no export server is started.
 
+### Export VirtualMachineTemplate
+
+Starting with KubeVirt v1.9.0, you can export a `VirtualMachineTemplate` as an
+OCI artifact. This requires both the `VMExport` and `OCIExport` feature gates
+(see below) as well as the `Template` feature gate. For more details on
+`VirtualMachineTemplates`, see
+[VirtualMachine Templates](../user_workloads/vm_templates.md).
+
+```yaml
+apiVersion: export.kubevirt.io/v1beta1
+kind: VirtualMachineExport
+metadata:
+  name: example-export
+spec:
+  tokenSecretRef: example-token
+  source:
+    apiGroup: "template.kubevirt.io"
+    kind: VirtualMachineTemplate
+    name: example-template
+```
+
+The template and all associated volume data are packaged into a single OCI
+artifact. Unlike VM and snapshot exports, the per-volume download links are not
+provided.
+
 ### Export Persistent Volume Claim
 
 You can create a VMExport CR that identifies the Persistent Volume Claim (PVC) you want to export. You can create a VMExport that looks like this:
@@ -259,6 +284,33 @@ There are 4 format types that are possible:
 
 Raw and Gzip will be selected if the PVC is determined to be a KubeVirt disk. KubeVirt disks contain a single disk.img file (or are a block device). Dir will return a list of the files in the PVC, to download a specific file you can replace `/dir` in the URL with the path and file name. For instance if the PVC contains the file `/example/data.txt` you can replace `/dir` with `/example/data.txt` to download just data.txt file. Or you can use the tar.gz URL to get all the contents of the PVC in a tar file.
 
+#### OCI format
+
+Starting with KubeVirt v1.9.0, VM exports can be downloaded as OCI image layout
+TARs. This packages the VM configuration and all disk volumes into a single OCI
+artifact that can be distributed through standard container registries using
+tools like skopeo, crane, or oras.
+
+OCI export requires the `OCIExport` feature gate to be enabled in addition to
+`VMExport`. See
+[Activating feature gates](../cluster_admin/activating_feature_gates.md) for
+details.
+
+To download an export in OCI format, use the `--format=oci` flag:
+
+```shell
+$ virtctl vmexport download example-export --format=oci --output=example-vm.oci.tar
+```
+
+The resulting TAR file conforms to the
+[OCI Image Layout Specification](https://github.com/opencontainers/image-spec/blob/main/image-layout.md)
+and can be pushed to a registry:
+
+```shell
+# podman unshare allows preserving UIDs in the TAR when skopeo is
+# extracting it
+$ podman unshare skopeo copy oci-archive:example-vm.oci.tar docker://registry.example.com/vms/example-vm:latest
+```
 
 #### Internal link certificates
 The export server certificate is valid for 7 days after which it is rotated by deleting the export server pod and associated secret and generating a new one. If for whatever reason the export server pod dies, the associated secret is also automatically deleted and a new pod and secret are generated. The VirtualMachineExport object status will be automatically updated to reflect the new certificate.
@@ -303,6 +355,7 @@ These three **functions** are:
 # --pvc, to specify the name of the pvc to export.
 # --snapshot, to specify the name of the VM snapshot to export.
 # --vm, to specify the name of the Virtual Machine to export.
+# --vmtemplate, to specify the name of the VirtualMachineTemplate to export (OCI only).
 
 $ virtctl vmexport create name [flags]
 ```
@@ -401,6 +454,7 @@ Flags:
       --snapshot          Sets VirtualMachineSnapshot as vmexport kind and specifies the snapshot name.
       --ttl               The time after the export was created that it is eligible to be automatically deleted. Defaults to 2 hours if not specified.
       --vm                Sets VirtualMachine as vmexport kind and specifies the VM name.
+      --vmtemplate        Sets VirtualMachineTemplate as vmexport kind and specifies the template name (OCI only).
       --volume            Specifies the volume to be downloaded.
 
 Use "virtctl options" for a list of global command-line options (applies to all commands).

--- a/docs/storage/export_api.md
+++ b/docs/storage/export_api.md
@@ -69,8 +69,9 @@ When you create a VMExport based on a Virtual Machine Snapshot, the controller w
 ### Export VirtualMachineTemplate
 
 Starting with KubeVirt v1.9.0, you can export a `VirtualMachineTemplate` as an
-OCI artifact. This requires both the `VMExport` and `OCIExport` feature gates
-(see below) as well as the `Template` feature gate. For more details on
+OCI artifact. This requires the [`OCIExport`](#oci-format) and `Template`
+feature gates, and the virt-template deployment must be enabled. `Template` and
+the virt-template deployment are enabled by default. For more details on
 `VirtualMachineTemplates`, see
 [VirtualMachine Templates](../user_workloads/vm_templates.md).
 

--- a/docs/user_workloads/vm_templates.md
+++ b/docs/user_workloads/vm_templates.md
@@ -5,6 +5,7 @@
 * `template.kubevirt.io/v1alpha1` (Alpha) as of the [
   `v1.8.0`](https://github.com/kubevirt/kubevirt/releases/tag/v1.8.0) KubeVirt
   release
+* `template.kubevirt.io/v1beta1` (Beta) as of the `v1.9.0` KubeVirt release
 
 ## Introduction
 
@@ -44,17 +45,27 @@ The feature introduces two Custom Resource Definitions:
 
 ## Enabling the feature
 
-The Template feature is an Alpha feature gate and must be explicitly enabled in
-the `KubeVirt` CR. This requires KubeVirt v1.8.0 or later. The `Snapshot`
-feature gate is also required as a dependency.
+Starting with KubeVirt v1.9.0, the Template feature gate is Beta and enabled by
+default. No action is required to enable it.
 
-Enable both feature gates by patching the `KubeVirt` CR:
+On KubeVirt v1.8.x, the Template feature gate is Alpha and must be explicitly
+enabled along with the `Snapshot` dependency:
 
 ```shell
 $ kubectl patch kubevirt kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates":["Snapshot","Template"]}}}}'
 ```
 
-Or add them to your `KubeVirt` CR YAML:
+Once enabled, KubeVirt automatically deploys the required components for native
+`VirtualMachineTemplates`.
+
+For more details on feature gates, see
+[Activating feature gates](../cluster_admin/activating_feature_gates.md).
+
+### Disabling virt-template deployment
+
+To disable the deployment of virt-template components while keeping the Template
+feature gate enabled, set `virtTemplateDeployment.enabled` to `false` in the
+`KubeVirt` CR:
 
 ```yaml
 apiVersion: kubevirt.io/v1
@@ -64,17 +75,9 @@ metadata:
   namespace: kubevirt
 spec:
   configuration:
-    developerConfiguration:
-      featureGates:
-        - Snapshot
-        - Template
+    virtTemplateDeployment:
+      enabled: false
 ```
-
-Once enabled, KubeVirt automatically deploys the required components for native
-`VirtualMachineTemplates`.
-
-For more details on feature gates, see
-[Activating feature gates](../cluster_admin/activating_feature_gates.md).
 
 !!! Note
     The `virtctl template` subcommands require virtctl v1.8.0 or later.
@@ -84,7 +87,7 @@ For more details on feature gates, see
 ### Overview
 
 A `VirtualMachineTemplate` is a namespaced resource in the
-`template.kubevirt.io/v1alpha1` API group.
+`template.kubevirt.io/v1beta1` API group.
 
 It consists of:
 
@@ -167,7 +170,7 @@ The following example defines a Fedora VM template with a generated name, a
 default instancetype and preference, and a required password parameter:
 
 ```yaml
-apiVersion: template.kubevirt.io/v1alpha1
+apiVersion: template.kubevirt.io/v1beta1
 kind: VirtualMachineTemplate
 metadata:
   name: fedora-template
@@ -290,7 +293,7 @@ private namespace.
 
 ```shell
 $ cat <<EOF | kubectl apply -f -
-apiVersion: template.kubevirt.io/v1alpha1
+apiVersion: template.kubevirt.io/v1beta1
 kind: VirtualMachineTemplateRequest
 metadata:
   name: promote-to-golden
@@ -321,7 +324,7 @@ While `containerDisk` is useful for testing, production templates often use
 `dataVolumeTemplates` to clone persistent storage from a golden image PVC.
 
 ```yaml
-apiVersion: template.kubevirt.io/v1alpha1
+apiVersion: template.kubevirt.io/v1beta1
 kind: VirtualMachineTemplate
 metadata:
   name: fedora-pvc-template
@@ -421,11 +424,34 @@ templates, not freeform. To achieve this:
 This ensures that all VMs are created from approved templates, giving
 administrators control over the VM configurations allowed in the cluster.
 
-## Limitations
+## OCI export
 
-!!! Warning
-    The Template API (`template.kubevirt.io/v1alpha1`) is an Alpha feature and may
-    change in future releases.
+Starting with KubeVirt v1.9.0, `VirtualMachineTemplates` can be exported as OCI
+artifacts using the [Export API](../storage/export_api.md). This allows you to
+distribute templates as container images through standard registries. The
+`OCIExport` and `Template` feature gates are required, and the
+[virt-template deployment](#disabling-virt-template-deployment) must be enabled.
+`Template` and the virt-template deployment are enabled by default.
 
-- The API is Alpha and subject to breaking changes
-- Import/export functionality (OVA/OVF) is planned for v1.9.0
+For full details on OCI export, feature gate setup, and pushing to registries,
+see the [Export API - OCI format](../storage/export_api.md#oci-format)
+documentation.
+
+### Exporting a template
+
+Create a VMExport for a `VirtualMachineTemplate` and download it in OCI format:
+
+```shell
+$ virtctl vmexport create my-export --vmtemplate=fedora-template
+$ virtctl vmexport download my-export --format=oci --output=fedora-template.oci.tar
+```
+
+The OCI artifact contains the template spec and all associated volume data.
+
+### Importing a template
+
+Native OCI import is planned for a future release (>= v1.10.0). In the
+meantime, the
+[`hack/oci-import.sh`](https://github.com/kubevirt/kubevirt/blob/main/hack/oci-import.sh)
+script can be used to import an exported template.
+


### PR DESCRIPTION
**What this PR does / why we need it**:

Update VM template and export API documentation for KubeVirt v1.9.0:
- Graduate Template feature gate from Alpha to Beta (enabled by default)
- Update API version from `v1alpha1` to `v1beta1`
- Document config-based disabling via `virtTemplateDeployment.enabled`
- Add OCI export format documentation and `VirtualMachineTemplate` as export source
- Add `--vmtemplate` flag to virtctl vmexport reference

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

On hold until the following PRs are merged:
- https://github.com/kubevirt/kubevirt/pull/18065 (Graduate Template feature gate to Beta)
- https://github.com/kubevirt/kubevirt/pull/18032 (Add OCI export support for VirtualMachineTemplates)

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```