### PR TITLE
docs: update PersistentReservation to GA, replace gate with config

### DIFF
--- a/docs/storage/disks_and_volumes.md
+++ b/docs/storage/disks_and_volumes.md
@@ -53,9 +53,9 @@ spec:
         claimName: mypvc
 ```
 #### persistent reservation
-It is possible to reserve a LUN through the the SCSI Persistent Reserve commands.
-In order to issue privileged SCSI ioctls, the VM requires activation of the
-persistent resevation flag:
+It is possible to reserve a LUN through the SCSI Persistent Reserve commands.
+In order to issue privileged SCSI ioctls, the VM requires enabling
+persistent reservation on the disk:
 
 ```yaml
 devices:
@@ -65,13 +65,12 @@ devices:
       reservation: true
 ```
 
-This feature is enabled by the feature gate `PersistentReservation`:
+This feature requires enabling persistent reservation in the KubeVirt configuration:
 
 ```yaml
 configuration:
-  developerConfiguration:
-    featureGates:
-    -  PersistentReservation
+  persistentReservationConfiguration:
+    enabled: true
 ```
 
 > **Note:** The persistent reservation feature enables an additional privileged


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update persistent reservation docs to reflect the GA promotion.
Replace the developerConfiguration feature gate with the new
persistentReservationConfiguration API and fix typos.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
