### PR TITLE
Fix grammar in migration policies documentation

### DIFF
--- a/docs/cluster_admin/migration_policies.md
+++ b/docs/cluster_admin/migration_policies.md
@@ -1,6 +1,6 @@
 # Migration Policies
 
-Migration policies provides a new way of applying migration configurations to Virtual Machines. The policies
+Migration policies provide a new way of applying migration configurations to Virtual Machines. The policies
 can refine Kubevirt CR's `MigrationConfiguration` that sets the cluster-wide migration configurations. This way,
 the cluster-wide settings serve as a default that can be refined (i.e. changed, removed or added) by the migration
 policy.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a grammar issue in the migration policies documentation by changing "Migration policies provides" to "Migration policies provide".

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Documentation-only change.

**Release note**:

```release-note
NONE
```
