### PR TITLE
Update outdated apiVersion in node overcommit example

### DIFF
--- a/docs/compute/node_overcommit.md
+++ b/docs/compute/node_overcommit.md
@@ -68,7 +68,7 @@ The following definition requests `1024MB` from the cluster but tells
 the VMI that it has `2048MB` of memory available:
 
 ```yaml
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   name: testvmi-nocloud


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the `VirtualMachineInstance` example in the node overcommit documentation from `kubevirt.io/v1alpha3` to `kubevirt.io/v1`.

The same document already contains `VirtualMachineInstance` examples using `kubevirt.io/v1`, and most VMI examples throughout the user guide use the stable `v1` API version. This change improves consistency and helps prevent confusion for users following the example.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Documentation-only change.

**Release note**:

```release-note
NONE
```
