### PR TITLE
docs: add storage migration RBAC permissions section

### DIFF
--- a/docs/storage/migration_controller.md
+++ b/docs/storage/migration_controller.md
@@ -166,3 +166,35 @@ test-migration   test-plan   Canceled   30s
 For multi-namespace migrations, delete the `MultiNamespaceVirtualMachineStorageMigration` resource — each child migration will be cancelled in the same way.
 
 > **Note:** This differs from KubeVirt's built-in [volume migration](volume_migration.md#volume-migration-cancellation), where cancellation requires applying the old VM spec to revert the volume set. With the migration controller, deleting the migration CR is sufficient — the controller handles the revert automatically.
+
+## Permissions
+
+The migration controller ships two non-aggregated ClusterRoles that
+cluster admins can explicitly bind to users who need to perform storage
+migration operations:
+
+| ClusterRole | Scope |
+|-------------|-------|
+| `migrations.kubevirt.io:storagemigrate` | Single-namespace storage migration |
+| `migrations.kubevirt.io:storagemigrate-multins` | Multi-namespace storage migration (superset of single-namespace) |
+
+These roles grant `get`, `list`, `watch`, `create`, `update`, `patch`,
+`delete`, and `deletecollection` permissions on storage migration
+resources. Neither role is aggregated into the built-in `admin`/`edit`
+roles, so they must be assigned explicitly.
+
+### Granting single-namespace storage migration access
+
+```shell
+kubectl create rolebinding my-storagemigrate \
+    --clusterrole=migrations.kubevirt.io:storagemigrate \
+    --user=<user> -n <namespace>
+```
+
+### Granting cluster-wide multi-namespace storage migration access
+
+```shell
+kubectl create clusterrolebinding my-storagemigrate-multins \
+    --clusterrole=migrations.kubevirt.io:storagemigrate-multins \
+    --user=<user>
+```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Document the two non-aggregated ClusterRoles
(storagemigrate, storagemigrate-multins) that cluster admins
can bind to users for storage migration operations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
