### PR TITLE
Fixed stale live migration docs

### DIFF
--- a/docs/compute/live_migration.md
+++ b/docs/compute/live_migration.md
@@ -14,14 +14,15 @@ field in the KubeVirt CR must be expanded by adding the `LiveMigration` to it.
 ## Limitations
 
 - Virtual machines using a PersistentVolumeClaim (PVC) must have a
-  shared ReadWriteMany (RWX) access mode to be live migrated.
+  shared ReadWriteMany (RWX) access mode to be live migrated, unless
+  the volume is also being migrated (see [volume migration](../storage/volume_migration.md)
+  and `status.migratedVolumes`).
 
 - Live migration is not allowed with a pod network binding of bridge
-  interface type
-  (</#/creation/interfaces-and-networks>)
+  interface type ([interfaces and networks](../network/interfaces_and_networks.md#bridge))
 
 - Live migration requires ports `49152, 49153` to be available in the virt-launcher pod.
-  If these ports are explicitly specified in [masquarade interface](../network/interfaces_and_networks.md#masquerade), live migration will not function.
+  If these ports are explicitly specified in [masquerade interface](../network/interfaces_and_networks.md#masquerade), live migration will not function.
 
 - Live migration requires the virt-launcher pod's primary network interface to have the same name on both source and target pods.
 
@@ -57,11 +58,9 @@ Live migration can also be initiated using virtctl
 
 When starting a virtual machine instance, it has also been calculated
 whether the machine is live migratable. The result is stored in
-the VMI `VMI.status.conditions`. The calculation can be based on
-multiple parameters of the VMI, however, at the moment, the calculation
-is largely based on the `Access Mode` of the VMI volumes. Live migration
-is only permitted when the volume access mode is set to `ReadWriteMany`.
-Requests to migrate a non-LiveMigratable VMI will be rejected.
+the VMI `VMI.status.conditions`. The calculation is based on
+multiple parameters of the VMI. Requests to migrate a non-LiveMigratable
+VMI will be rejected.
 
 The reported `Migration Method` is also calculated during VMI
 start. `BlockMigration` indicates that some of the VMI disks require
@@ -86,22 +85,25 @@ Below is an example of a successful migration.
 
 ```
 Migration State:
-    Completed:        true
-    End Timestamp:    2019-03-29T03:37:52Z
+    Completed:                               true
+    End Timestamp:                           2019-03-29T03:37:52Z
     Migration Config:
-      Completion Timeout Per GiB:  800
-      Progress Timeout:             150
-    Migration UID:                  c64d4898-51d3-11e9-b370-525500d15501
-    Source Node:                    node02
-    Start Timestamp:                2019-03-29T04:02:47Z
+      Completion Timeout Per GiB:            150
+      Progress Timeout:                      150
+    Migration UID:                           c64d4898-51d3-11e9-b370-525500d15501
+    Mode:                                    PreCopy
+    Source Node:                             node02
+    Source Pod:                              virt-launcher-testvmi-source
+    Start Timestamp:                         2019-03-29T03:37:16Z
     Target Direct Migration Node Ports:
-      35001:                      0
-      41068:                      49152
-      38284:                      49153
-    Target Node:                  node01
-    Target Node Address:          10.128.0.46
-    Target Node Domain Detected:  true
-    Target Pod:                   virt-launcher-testvmimcbjgw6zrzcmp8wpddvztvzm7x2k6cjbdgktwv8tkq
+      35001:                                 0
+      41068:                                 49152
+      38284:                                 49153
+    Target Node:                             node01
+    Target Node Address:                     10.128.0.46
+    Target Node Domain Detected:             true
+    Target Node Domain Ready Timestamp:      2019-03-29T03:37:51Z
+    Target Pod:                              virt-launcher-testvmi-target
 ```
 
 ## Canceling a live migration
@@ -114,25 +116,27 @@ and `Failed`.
 
 ```
 Migration State:
-    Abort Requested:  true
-    Abort Status:     Succeeded
-    Completed:        true
-    End Timestamp:    2019-03-29T04:02:49Z
-    Failed:           true
+    Abort Requested:                         true
+    Abort Status:                            Succeeded
+    Completed:                               true
+    End Timestamp:                           2019-03-29T04:02:49Z
+    Failed:                                  true
     Migration Config:
-      Completion Timeout Per GiB:  800
-      Progress Timeout:             150
-    Migration UID:                  57a693d6-51d7-11e9-b370-525500d15501
-    Source Node:                    node02
-    Start Timestamp:                2019-03-29T04:02:47Z
+      Completion Timeout Per GiB:            150
+      Progress Timeout:                      150
+    Migration UID:                           57a693d6-51d7-11e9-b370-525500d15501
+    Mode:                                    PreCopy
+    Source Node:                             node02
+    Source Pod:                              virt-launcher-testvmi-source
+    Start Timestamp:                         2019-03-29T04:02:47Z
     Target Direct Migration Node Ports:
-      39445:                      0
-      43345:                      49152
-      44222:                      49153
-    Target Node:                  node01
-    Target Node Address:          10.128.0.46
-    Target Node Domain Detected:  true
-    Target Pod:                   virt-launcher-testvmimcbjgw6zrzcmp8wpddvztvzm7x2k6cjbdgktwv8tkq
+      39445:                                 0
+      43345:                                 49152
+      44222:                                 49153
+    Target Node:                             node01
+    Target Node Address:                     10.128.0.46
+    Target Node Domain Detected:             true
+    Target Pod:                              virt-launcher-testvmi-target
 ```
 
 ### Using virtctl to cancel a live migration
@@ -147,14 +151,15 @@ of a VMI which is currently being migrated
 KubeVirt puts some limits in place, so that migrations don't overwhelm
 the cluster. By default, it is configured to only run `5` migrations in
 parallel with an additional limit of a maximum of `2` outbound
-migrations per node. Finally, every migration is limited to a bandwidth
-of `64MiB/s`.
+migrations per node. Bandwidth per migration is unlimited by default
+(`0Mi`).
 
-These values can be changed in the `kubevirt` CR:
+You can override these and other migration settings in the `kubevirt` CR.
+The following example shows the current defaults:
 
 ```yaml
 apiVersion: kubevirt.io/v1
-kind: Kubevirt
+kind: KubeVirt
 metadata:
   name: kubevirt
   namespace: kubevirt
@@ -163,8 +168,8 @@ spec:
     migrations:
       parallelMigrationsPerCluster: 5
       parallelOutboundMigrationsPerNode: 2
-      bandwidthPerMigration: 64Mi
-      completionTimeoutPerGiB: 800
+      bandwidthPerMigration: 0Mi
+      completionTimeoutPerGiB: 150
       progressTimeout: 150
       disableTLS: false
       nodeDrainTaintKey: "kubevirt.io/drain"
@@ -271,18 +276,18 @@ alternative strategies below.
 
 For virtual machines that explicitly set CPU resource limits, multithreaded migration is disabled and single-threaded migration will be used instead.
 ### Post-copy
-The way post-copy migrations work is as following:
+In KubeVirt, migrations always start in pre-copy mode and may later
+switch to post-copy. Once in post-copy:
 
-  1. The target VM is created.
-  2. The guest is run on the **target VM**.
-  3. The source starts sending chunks of VM state (mostly memory) to the target.
-  4. When the guest, running on the target VM, would access memory:
+  1. The guest runs on the **target VM**.
+  2. The source continues sending chunks of VM state (mostly memory) to the target.
+  3. When the guest, running on the target VM, would access memory:
     1. If the memory exists on the target VM, the guest can access it.
     2. Otherwise, the target VM asks for a chunk of memory from the source VM.
-  5. Once all of the memory state is updated at the target VM, the source VM is removed.
+  4. Once all of the memory state is updated at the target VM, the source VM is removed.
 
-The main idea here is that the guest starts to run immediately on the target VM. This approach
-has advantages and disadvantages:
+The main idea of post-copy is that the guest runs on the target VM while
+remaining memory is fetched on demand. This approach has advantages and disadvantages:
 
 <u>advantages</u>:
 
@@ -425,15 +430,12 @@ This is just a matter of adding the name of the
 NetworkAttachmentDefinition to the KubeVirt CR, like so:
 ```yaml
 apiVersion: kubevirt.io/v1
-kind: Kubevirt
+kind: KubeVirt
 metadata:
   name: kubevirt
   namespace: kubevirt
 spec:
   configuration:
-    developerConfiguration:
-      featureGates:
-      - LiveMigration
     migrations:
       network: migration-network
 ```
@@ -504,15 +506,12 @@ improve performance. Use `disableTLS` to do that:
 
 ```yaml
 apiVersion: kubevirt.io/v1
-kind: Kubevirt
+kind: KubeVirt
 metadata:
   name: kubevirt
   namespace: kubevirt
 spec:
   configuration:
-    developerConfiguration:
-      featureGates:
-        - "LiveMigration"
     migrations:
       disableTLS: true
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:

Refreshes stale live migration documentation to match current KubeVirt behavior and defaults:

- PVC live migration allows volume migration / `status.migratedVolumes` as an alternative to RWX
- Fix masquerade link typo and bridge interface doc link
- Migratability is no longer described as RWX-only
- Migration status examples include `Mode`, `Source Pod`, and current default timeouts (`completionTimeoutPerGiB: 150`)
- Default migration bandwidth is unlimited (`0Mi`), not `64Mi`
- Cluster config examples use `kind: KubeVirt` and drop obsolete `LiveMigration` feature-gate snippets
- Clarify that migrations always start in pre-copy and may later switch to post-copy

Compatible with #1021 (Migration Stall Detector docs): both touch `docs/compute/live_migration.md` but in non-overlapping sections and auto-merge cleanly. Prefer merging #1021 first (already approved); this PR rebases cleanly either before or after.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Self-review note about inconsistent timeout examples (status dump showed 150 while the CR example still had 800) is addressed in this update.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```