### PR TITLE
Fix table rendering with CSS specificity override

### DIFF
--- a/docs/compute/run_strategies.md
+++ b/docs/compute/run_strategies.md
@@ -58,48 +58,12 @@ The `start`, `stop` and `restart` methods of virtctl will invoke their
 respective subresources of VirtualMachines. This can have an effect on
 the runStrategy of the VirtualMachine as below:
 
-<table style="width: 100% ; display: inline-table">
-<colgroup>
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>RunStrategy</th>
-<th>start</th>
-<th>stop</th>
-<th>restart</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td><p><strong>Always</strong></p></td>
-<td><p><code>-</code></p></td>
-<td><p><code>Halted</code></p></td>
-<td><p><code>Always</code></p></td>
-</tr>
-<tr class="even">
-<td><p><strong>RerunOnFailure</strong></p></td>
-<td><p><code>RerunOnFailure</code></p></td>
-<td><p><code>RerunOnFailure</code></p></td>
-<td><p><code>RerunOnFailure</code></p></td>
-</tr>
-<tr class="odd">
-<td><p><strong>Manual</strong></p></td>
-<td><p><code>Manual</code></p></td>
-<td><p><code>Manual</code></p></td>
-<td><p><code>Manual</code></p></td>
-</tr>
-<tr class="even">
-<td><p><strong>Halted</strong></p></td>
-<td><p><code>Always</code></p></td>
-<td><p><code>-</code></p></td>
-<td><p><code>-</code></p></td>
-</tr>
-</tbody>
-</table>
+| RunStrategy        | start              | stop               | restart            |
+|--------------------|--------------------|--------------------|--------------------| 
+| **Always**         | `-`                | `Halted`           | `Always`           |
+| **RerunOnFailure** | `RerunOnFailure`   | `RerunOnFailure`   | `RerunOnFailure`   |
+| **Manual**         | `Manual`           | `Manual`           | `Manual`           |
+| **Halted**         | `Always`           | `-`                | `-`                |
 
 Table entries marked with `-` don't make sense, so won't have an effect
 on RunStrategy.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -33,6 +33,7 @@
   border: 1px solid #e1e4e5;
 }
 
-.md-typeset__table {
-   min-width: 100%;
+.md-typeset table:not([class]) {
+   display: table;
+   width: max-content;
 }


### PR DESCRIPTION
Previously KubeVirt tables were rendering full width, even when the total width of columns didn't need it. This resulted in the last column having a sea of dead space next to it. It was wrong and made me sad.

Robot found the problem, which we're fixing here. Original solution was to fix all tables at full width but that was wrong for different reasons. 
This solution let's the table decide it's own width based on content. 

While checking that this was universally acceptable, I noticed the runstrategies table had dangling characters and was actually written in html instead of markdown. This was probably due to markdown limitations of a time past that no longer apply as it builds as expected now with minimum md.
Tagging @jean-edouard in case there was another reason for that I am unable to discern. 


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1013

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixing table render issue with css update
```
