### PR TITLE
document live migration compression

### DIFF
--- a/docs/compute/live_migration.md
+++ b/docs/compute/live_migration.md
@@ -548,6 +548,36 @@ are technically dense and algorithm-specific; for details on what they do, see t
 API Reference or
 [VEP 248](https://github.com/kubevirt/enhancements/tree/main/veps/sig-compute/248-migration-convergence).
 
+### Compression
+
+**FEATURE STATE:** KubeVirt v1.9 (Alpha)
+
+Large-memory VMs or bandwidth-constrained environments often hit migration timeouts because the guest dirty rate exceeds the available link capacity. Compression reduces the amount of data sent over the network by compressing memory pages on the migration stream. This trades modest CPU overhead on the source node for lower bandwidth use and can help migrations converge that would otherwise time out. The feature is alpha and opt-in per workload via [MigrationPolicy](../cluster_admin/migration_policies.md).
+
+Set `spec.experimental.compression` to `zstd` on a `MigrationPolicy` that matches the target VMs. Omit the field or set it to `none` to leave compression disabled (the default).
+
+```yaml
+apiVersion: migrations.kubevirt.io/v1alpha1
+kind: MigrationPolicy
+metadata:
+  name: compress-heavy-vms
+spec:
+  selectors:
+    namespaceSelector:
+      workload-type: memory-intensive
+  experimental:
+    compression: zstd
+```
+
+There is only one configuration option:
+
+- `compression` (default: `none`): when set to `zstd`, virt-launcher enables QEMU/libvirt zstd compression on the live migration data stream. In alpha this lives under `MigrationPolicy.spec.experimental`
+  ([ExperimentalMigrationOptions](https://kubevirt.io/api-reference/main/definitions.html#_v1_experimentalmigrationoptions)).
+  Only `zstd` is supported today; `none` explicitly disables compression for matched VMs.
+
+When compression is active, virt-launcher migration logs include `Migration compression enabled: method=zstd` and a `CompressionRatio` value in migration progress lines. Compression is compatible with multifd parallel channels (the default when no per-migration CPU limit is set), TLS, bandwidth limits, auto-converge, post-copy, and stall detection. For design details, see
+[VEP 246](https://github.com/kubevirt/enhancements/tree/main/veps/sig-compute/246-migration-compression).
+
 ## Disabling secure migrations
 
 **FEATURE STATE:** KubeVirt v0.43


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
document alpha live migration compression feature

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
