### PR TITLE
net, interface & networks: Update deprecation warning

### DIFF
--- a/docs/network/interfaces_and_networks.md
+++ b/docs/network/interfaces_and_networks.md
@@ -121,7 +121,10 @@ spec:
 ```
 
 #### Network Resource Injection
-[v1.8]
+Releases:
+- v1.8: Beta
+- v1.9: Beta (enabled by default)
+- v1.10: GA
 
 Some secondary network configurations use the `k8s.v1.cni.cncf.io/resourceName`
 `NetworkAttachmentDefinition` (NAD) annotation to indicate that a network device resource
@@ -141,18 +144,20 @@ For installation instructions, refer to the
 
 !!! warning "Deprecation Notice"
     Prior to v1.8, KubeVirt's virt-controller queried NAD objects directly to inject network resource
-    requirements into virt-launcher pods. This behavior is deprecated and controlled by the
-    `ExternalNetResourceInjection` feature gate.
+    requirements into virt-launcher pods. This legacy behavior is deprecated and is now controlled by
+    the `ExternalNetResourceInjection` feature gate.
 
-    - **v1.8**: The `ExternalNetResourceInjection` feature gate is introduced, disabled by default.
+    - **v1.8**: The `ExternalNetResourceInjection` feature gate was introduced, disabled by default.
       When enabled, KubeVirt no longer queries NADs or deploys associated RBAC rules — the
       `network-resources-injector` is expected to handle resource injection instead.
-    - In a future release, the feature gate will be enabled by default. Users will still be able to
-      disable it to fall back to the legacy behavior.
-    - In a subsequent release, the legacy NAD query code will be removed entirely.
+    - **v1.9**: The feature gate was enabled by default. Users can still disable it to
+      fall back to the legacy behavior.
+    - **v1.10**: The `ExternalNetResourceInjection` feature gate graduated to general availability (GA),
+      and the legacy NAD query code is removed entirely.
 
-    Cluster administrators using the affected use cases should deploy `network-resources-injector`
-    before enabling the feature gate or upgrading to a release where it is enabled by default.
+    Cluster administrators using the affected use cases must deploy `network-resources-injector`
+    before enabling the `ExternalNetResourceInjection` feature gate or upgrading to v1.9 or v1.10,
+    where it is enabled by default - on v1.10 there is no legacy fallback.
 
 #### Multus as primary network provider
 It is also possible to define a multus network as the default pod


### PR DESCRIPTION

**What this PR does / why we need it**:
Updated deprecation warning on user-guide/network/Interfaces&Networks/NetworkResourceInjection
Now reflects v1.9 this feature is enabled by default as beta & the GA status in v1.10.

**References**
[VEP106](https://github.com/kubevirt/kubevirt/pull/18497)
[+VEP106](https://github.com/kubevirt/enhancements/issues/106)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
